### PR TITLE
fix: Switch shutdown handler library 

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,9 @@ var Q = require('kew')
 var ipfs = require('ipfs-api')
 var multiaddr = require('multiaddr')
 var waterfall = require('promise-waterfall')
-var shutdown = require('shutdown-handler')
 var rimraf = require('rimraf')
 var fs = require('fs')
+var shutdown = require('shutdown')
 
 var IPFS_EXEC = require('go-ipfs')
 var GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
@@ -74,17 +74,16 @@ var Node = function (path, opts, disposable) {
           })
         })
       if (disposable) {
-        shutdown.on('exit', t.shutdown.bind(t))
+        shutdown.addHandler('disposable', 1, t.shutdown.bind(t))
       }
     },
     // cleanup tmp files
-    shutdown: function (e) {
+    shutdown: function (done) {
       var t = this
       if (!t.clean && disposable) {
-        e.preventDefault()
         rimraf(t.path, function (err) {
           if (err) throw err
-          process.exit(0)
+          done()
         })
       }
     },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "multiaddr": "^1.0.0",
     "promise-waterfall": "0.1.0",
     "rimraf": "^2.3.4",
-    "shutdown-handler": "^1.0.1",
+    "shutdown": "^0.2.4",
     "subcomandante": "^1.0.3"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   },
   "author": "Juan Benet <juan@benet.ai> (http://juan.benet.ai/)",
   "contributors": [
-    "Kristoffer Ström <kristoffer@rymdkoloni.se>"
+    "Kristoffer Ström <kristoffer@rymdkoloni.se>",
+    "Friedel Ziegelmayer <dignifiedquire@gmail.com>"
   ],
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
This library properly exits the process on errors and does not
interfere on `require`.
Ref https://github.com/ipfs/js-ipfs-api/issues/88
Fixes #19