### PR TITLE
Update ipfs-api package version...

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "ipfs-api": "^2.10.1",
+    "ipfs-api": "^3.0.0",
     "go-ipfs-dep": "0.4.0-1",
     "multiaddr": "^1.1.1",
     "rimraf": "^2.4.5",

--- a/test/test.js
+++ b/test/test.js
@@ -6,6 +6,7 @@ const ipfsApi = require('ipfs-api')
 const run = require('subcomandante')
 const fs = require('fs')
 const rimraf = require('rimraf')
+const path = require('path')
 
 // this comment is used by mocha, do not delete
 /*global describe, before, it*/
@@ -104,7 +105,7 @@ describe('disposableApi node', function () {
 })
 
 describe('starting and stopping', function () {
-  this.timeout(10000)
+  this.timeout(20000)
   let node
 
   describe('init', () => {
@@ -291,6 +292,34 @@ describe('version', () => {
       if (err) throw err
 
       assert(version)
+      done()
+    })
+  })
+})
+
+describe('ipfs-api version', function() {
+  this.timeout(20000)
+
+  let ipfs
+
+  before(done => {
+    ipfsd.disposable((err, node) => {
+      if (err) throw err
+      node.startDaemon((err, ignore) => {
+        if (err) throw err
+        ipfs = ipfsApi(node.apiAddr)
+        done()
+      })
+    })
+  })
+
+  it('uses the correct ipfs-api', done => {
+    ipfs.add(path.join(__dirname, '../lib'), { recursive: true }, (err, res) => {
+      if (err) throw err
+
+      const added = res[res.length - 1]
+      assert(added)
+      assert.equal(added.Hash, 'QmWab9Js2ueyo739mUdLxv45u6YkEgd3LmzXKn4SQjcFuq')
       done()
     })
   })


### PR DESCRIPTION
...and add a test to make sure we're using the right version of ipfs-api.

The module is currently **BROKEN** as it's using a different version of ipfs-api: 
*Adding a directory recursively returns a different hash every time. This seems to be due to ipfs-api version mismatch (2.10.x vs. 3.0.0). This pull request will update the ipfs-api package version and fix the problem (verified by the test in the PR).*