### PR TITLE
Fix default IPFS exec path when used via Electron

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,7 @@ module.exports = {
         done(null, node)
       })
     } else {
-      node.init(err => {
+      node.init((err) => {
         done(err, node)
       })
     }

--- a/lib/node.js
+++ b/lib/node.js
@@ -10,7 +10,7 @@ const shutdown = require('shutdown')
 const path = require('path')
 const join = path.join
 
-const rootPath = process.versions['electron'] ? process.resourcesPath + '/app/' : process.cwd();
+const rootPath = process.versions['electron'] ? process.resourcesPath + '/app/' : process.cwd()
 const ipfsDefaultPath = path.join(rootPath, 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
 const GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
 
@@ -56,7 +56,9 @@ module.exports = class Node {
     let result = ''
     run(this.exec, args, envArg)
       .on('error', done)
-      .on('data', data => result += data)
+      .on('data', (data) => {
+        result += data
+      })
       .on('end', () => done(null, result.trim()))
   }
 
@@ -76,9 +78,11 @@ module.exports = class Node {
 
     run(this.exec, ['init', '-b', keySize], {env: this.env})
       .on('error', done)
-      .on('data', data => buf += data)
+      .on('data', (data) => {
+        buf += data
+      })
       .on('end', () => {
-        configureNode(this, this.opts, err => {
+        configureNode(this, this.opts, (err) => {
           if (err) return done(err)
           this.clean = false
           this.initialized = true
@@ -94,7 +98,7 @@ module.exports = class Node {
   // cleanup tmp files
   shutdown (done) {
     if (!this.clean && this.disposable) {
-      rimraf(this.path, err => {
+      rimraf(this.path, (err) => {
         if (err) throw err
         done()
       })
@@ -106,7 +110,7 @@ module.exports = class Node {
       if (err) return done(err)
 
       this.subprocess = run(this.exec, ['daemon'], {env: this.env})
-        .on('error', err => {
+        .on('error', (err) => {
           if ((err + '').match('daemon is running')) {
             // we're good
             done(null, ipfs(conf.Addresses.API))
@@ -116,7 +120,7 @@ module.exports = class Node {
             done(err)
           }
         })
-        .on('data', data => {
+        .on('data', (data) => {
           const match = (data + '').trim().match(/API server listening on (.*)/)
           if (match) {
             this.apiAddr = match[1]
@@ -165,7 +169,7 @@ module.exports = class Node {
   setConfig (key, value, done) {
     run(this.exec, ['config', key, value, '--json'], {env: this.env})
       .on('error', done)
-      .on('data', data => {})
+      .on('data', (data) => {})
       .on('end', () => done())
   }
 

--- a/lib/node.js
+++ b/lib/node.js
@@ -10,7 +10,8 @@ const shutdown = require('shutdown')
 const path = require('path')
 const join = path.join
 
-const ipfsDefaultPath = path.join(process.cwd(), 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
+const rootPath = process.versions['electron'] ? process.resourcesPath + '/app/' : process.cwd();
+const ipfsDefaultPath = path.join(rootPath, 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
 const GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
 
 function configureNode (node, conf, done) {

--- a/test/test.js
+++ b/test/test.js
@@ -10,11 +10,12 @@ const path = require('path')
 
 // this comment is used by mocha, do not delete
 /*global describe, before, it*/
+
 describe('ipfs executable path', function () {
   this.timeout(2000)
   let Node
 
-  it('has the correct path when used via Electron', (done) => {
+  it('has the correct path when used via Electron', () => {
     process.versions['electron'] = '0.0.0-test'   // Electron sets its version to the array --> we know that we're using Electron
     process.resourcesPath = '/test/path/one/more' // Path to the Electron app, set by Electron
 
@@ -24,10 +25,9 @@ describe('ipfs executable path', function () {
 
     var node = new Node()
     assert.equal(node.exec, path.join(process.resourcesPath, '/app', 'node_modules/go-ipfs-dep/go-ipfs/ipfs'))
-    done()
   })
 
-  it('has the correct path when used via Node.js', (done) => {
+  it('has the correct path when used via Node.js', () => {
     delete process.versions['electron']
     delete process.resourcesPath
 
@@ -37,7 +37,6 @@ describe('ipfs executable path', function () {
 
     var node = new Node()
     assert.equal(node.exec, path.join(process.cwd(), 'node_modules/go-ipfs-dep/go-ipfs/ipfs'))
-    done()
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -10,6 +10,37 @@ const path = require('path')
 
 // this comment is used by mocha, do not delete
 /*global describe, before, it*/
+describe('ipfs executable path', function () {
+  this.timeout(2000)
+  let Node;
+
+  it('has the correct path when used via Electron', done => {
+    process.versions['electron'] = '0.0.0-test'   // Electron sets its version to the array --> we know that we're using Electron
+    process.resourcesPath = '/test/path/one/more' // Path to the Electron app, set by Electron
+
+    // Force reload of the module (pathing is handled globally in ../lib/node.js)
+    delete require.cache[require.resolve('../lib/node.js')]
+    Node = require('../lib/node.js')
+
+    var node = new Node();
+    assert.equal(node.exec, path.join(process.resourcesPath, '/app', 'node_modules/go-ipfs-dep/go-ipfs/ipfs'));
+    done()
+  })
+
+  it('has the correct path when used via Node.js', done => {
+    delete process.versions['electron']
+    delete process.resourcesPath;
+
+    // Force reload of the module (pathing is handled globally in ../lib/node.js)
+    delete require.cache[require.resolve('../lib/node.js')]
+    Node = require('../lib/node.js')
+
+    var node = new Node();
+    assert.equal(node.exec, path.join(process.cwd(), 'node_modules/go-ipfs-dep/go-ipfs/ipfs'));
+    done()
+  })
+
+})
 
 describe('disposable node with local api', function () {
   this.timeout(20000)
@@ -313,13 +344,14 @@ describe('ipfs-api version', function () {
     })
   })
 
+  // NOTE: if you change ../lib/node.js, the hash will need to be changed
   it('uses the correct ipfs-api', done => {
     ipfs.add(path.join(__dirname, '../lib'), { recursive: true }, (err, res) => {
       if (err) throw err
 
       const added = res[res.length - 1]
       assert(added)
-      assert.equal(added.Hash, 'QmWab9Js2ueyo739mUdLxv45u6YkEgd3LmzXKn4SQjcFuq')
+      assert.equal(added.Hash, 'QmbMm9AGVRBh2N4z2dp1BdTdHGifZkVQrJ5SLij7NG6S68')
       done()
     })
   })

--- a/test/test.js
+++ b/test/test.js
@@ -12,9 +12,9 @@ const path = require('path')
 /*global describe, before, it*/
 describe('ipfs executable path', function () {
   this.timeout(2000)
-  let Node;
+  let Node
 
-  it('has the correct path when used via Electron', done => {
+  it('has the correct path when used via Electron', (done) => {
     process.versions['electron'] = '0.0.0-test'   // Electron sets its version to the array --> we know that we're using Electron
     process.resourcesPath = '/test/path/one/more' // Path to the Electron app, set by Electron
 
@@ -22,30 +22,29 @@ describe('ipfs executable path', function () {
     delete require.cache[require.resolve('../lib/node.js')]
     Node = require('../lib/node.js')
 
-    var node = new Node();
-    assert.equal(node.exec, path.join(process.resourcesPath, '/app', 'node_modules/go-ipfs-dep/go-ipfs/ipfs'));
+    var node = new Node()
+    assert.equal(node.exec, path.join(process.resourcesPath, '/app', 'node_modules/go-ipfs-dep/go-ipfs/ipfs'))
     done()
   })
 
-  it('has the correct path when used via Node.js', done => {
+  it('has the correct path when used via Node.js', (done) => {
     delete process.versions['electron']
-    delete process.resourcesPath;
+    delete process.resourcesPath
 
     // Force reload of the module (pathing is handled globally in ../lib/node.js)
     delete require.cache[require.resolve('../lib/node.js')]
     Node = require('../lib/node.js')
 
-    var node = new Node();
-    assert.equal(node.exec, path.join(process.cwd(), 'node_modules/go-ipfs-dep/go-ipfs/ipfs'));
+    var node = new Node()
+    assert.equal(node.exec, path.join(process.cwd(), 'node_modules/go-ipfs-dep/go-ipfs/ipfs'))
     done()
   })
-
 })
 
 describe('disposable node with local api', function () {
   this.timeout(20000)
   let ipfs
-  before(done => {
+  before((done) => {
     ipfsd.disposable((err, node) => {
       if (err) throw err
       node.startDaemon((err, ignore) => {
@@ -63,7 +62,7 @@ describe('disposable node with local api', function () {
 
   let store, retrieve
 
-  before(done => {
+  before((done) => {
     const blorb = Buffer('blorb')
     ipfs.block.put(blorb, (err, res) => {
       if (err) throw err
@@ -73,7 +72,9 @@ describe('disposable node with local api', function () {
         if (err) throw err
         let buf = ''
         res
-          .on('data', data => buf += data)
+          .on('data', (data) => {
+            buf += data
+          })
           .on('end', () => {
             retrieve = buf
             done()
@@ -92,7 +93,7 @@ describe('disposable node with local api', function () {
 describe('disposableApi node', function () {
   this.timeout(20000)
   let ipfs
-  before(done => {
+  before((done) => {
     ipfsd.disposableApi((err, api) => {
       if (err) throw err
       ipfs = api
@@ -109,7 +110,7 @@ describe('disposableApi node', function () {
 
   let store, retrieve
 
-  before(done => {
+  before((done) => {
     const blorb = Buffer('blorb')
     ipfs.block.put(blorb, (err, res) => {
       if (err) throw err
@@ -119,7 +120,9 @@ describe('disposableApi node', function () {
         if (err) throw err
         let buf = ''
         res
-          .on('data', data => buf += data)
+          .on('data', (data) => {
+            buf += data
+          })
           .on('end', () => {
             retrieve = buf
             done()
@@ -140,7 +143,7 @@ describe('starting and stopping', function () {
   let node
 
   describe('init', () => {
-    before(done => {
+    before((done) => {
       ipfsd.disposable((err, res) => {
         if (err) throw err
         node = res
@@ -161,7 +164,7 @@ describe('starting and stopping', function () {
 
   describe('starting', () => {
     let ipfs
-    before(done => {
+    before((done) => {
       node.startDaemon((err, res) => {
         if (err) throw err
 
@@ -170,7 +173,7 @@ describe('starting and stopping', function () {
 
         // actually running?
         run('kill', ['-0', pid])
-          .on(err, err => { throw err })
+          .on(err, (err) => { throw err })
           .on('end', () => { done() })
       })
     })
@@ -182,8 +185,8 @@ describe('starting and stopping', function () {
 
   let stopped = false
   describe('stopping', () => {
-    before(done => {
-      node.stopDaemon(err => {
+    before((done) => {
+      node.stopDaemon((err) => {
         if (err) throw err
         stopped = true
       })
@@ -209,7 +212,7 @@ describe('setting up and initializing a local node', () => {
   const testpath1 = '/tmp/ipfstestpath1'
 
   describe('cleanup', () => {
-    before(done => {
+    before((done) => {
       rimraf(testpath1, done)
     })
 
@@ -220,7 +223,7 @@ describe('setting up and initializing a local node', () => {
 
   describe('setup', () => {
     let node
-    before(done => {
+    before((done) => {
       ipfsd.local(testpath1, (err, res) => {
         if (err) throw err
         node = res
@@ -239,8 +242,8 @@ describe('setting up and initializing a local node', () => {
     describe('initialize', function () {
       this.timeout(10000)
 
-      before(done => {
-        node.init(err => {
+      before((done) => {
+        node.init((err) => {
           if (err) throw err
           done()
         })
@@ -266,7 +269,7 @@ describe('change config values of a disposable node', function () {
 
   let ipfsNode
 
-  before(done => {
+  before((done) => {
     ipfsd.disposable((err, node) => {
       if (err) {
         throw err
@@ -276,7 +279,7 @@ describe('change config values of a disposable node', function () {
     })
   })
 
-  it('Should return a config value', done => {
+  it('Should return a config value', (done) => {
     ipfsNode.getConfig('Bootstrap', (err, config) => {
       if (err) {
         throw err
@@ -286,8 +289,8 @@ describe('change config values of a disposable node', function () {
     })
   })
 
-  it('Should set a config value', done => {
-    ipfsNode.setConfig('Bootstrap', null, err => {
+  it('Should set a config value', (done) => {
+    ipfsNode.setConfig('Bootstrap', null, (err) => {
       if (err) {
         throw err
       }
@@ -304,7 +307,7 @@ describe('change config values of a disposable node', function () {
 })
 
 describe('external ipfs binaray', () => {
-  it('allows passing via $IPFS_EXEC', done => {
+  it('allows passing via $IPFS_EXEC', (done) => {
     process.env.IPFS_EXEC = '/some/path'
     ipfsd.local((err, node) => {
       if (err) throw err
@@ -318,7 +321,7 @@ describe('external ipfs binaray', () => {
 })
 
 describe('version', () => {
-  it('prints the version', done => {
+  it('prints the version', (done) => {
     ipfsd.version((err, version) => {
       if (err) throw err
 
@@ -333,7 +336,7 @@ describe('ipfs-api version', function () {
 
   let ipfs
 
-  before(done => {
+  before((done) => {
     ipfsd.disposable((err, node) => {
       if (err) throw err
       node.startDaemon((err, ignore) => {
@@ -345,13 +348,13 @@ describe('ipfs-api version', function () {
   })
 
   // NOTE: if you change ../lib/node.js, the hash will need to be changed
-  it('uses the correct ipfs-api', done => {
+  it('uses the correct ipfs-api', (done) => {
     ipfs.add(path.join(__dirname, '../lib'), { recursive: true }, (err, res) => {
       if (err) throw err
 
       const added = res[res.length - 1]
       assert(added)
-      assert.equal(added.Hash, 'QmbMm9AGVRBh2N4z2dp1BdTdHGifZkVQrJ5SLij7NG6S68')
+      assert.equal(added.Hash, 'QmTioWzyNf4ybt6RDYCxqWBGYBfDqFWCoNwRKF89xgUvgF')
       done()
     })
   })


### PR DESCRIPTION
process.cwd() in Electron will always return '/' instead of the current directory (https://github.com/electron/electron/issues/2108). By checking if we're using Electron, we can get Electron app's default folder instead of '/'.

```javascript
const rootPath = process.versions['electron'] ? process.resourcesPath + '/app/' : process.cwd()
const ipfsDefaultPath = path.join(rootPath, 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
```

This PR adds that check and tests to cover the Electron vs Node.js use cases.