### PR TITLE
add check for npm2 path and remove electron path check

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -10,9 +10,24 @@ const shutdown = require('shutdown')
 const path = require('path')
 const join = path.join
 
-const rootPath = process.versions['electron'] ? process.resourcesPath + '/app/' : process.cwd()
-const ipfsDefaultPath = path.join(rootPath, 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
+const rootPath = process.env.testpath ? process.env.testpath : __dirname
+
+const ipfsDefaultPath = findIpfsExecutable()
+
 const GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
+
+function findIpfsExecutable () {
+  let npm3Path = path.join(rootPath, '../../', '/go-ipfs-dep/go-ipfs/ipfs')
+
+  let npm2Path = path.join(rootPath, '../', 'node_modules/go-ipfs-dep/go-ipfs/ipfs')
+
+  try {
+    fs.statSync(npm3Path)
+    return npm3Path
+  } catch (e) {
+    return npm2Path
+  }
+}
 
 function configureNode (node, conf, done) {
   if (Object.keys(conf).length > 0) {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "estraverse": "^4.1.1",
+    "mkdirp": "^0.5.1",
     "mocha": "^2.3.4",
     "pre-commit": "^1.1.2",
     "standard": "^6.0.8"

--- a/test/test.js
+++ b/test/test.js
@@ -21,7 +21,10 @@ describe('ipfs executable path', function () {
     let npm3Path = '/tmp/ipfsd-ctl-test/node_modules/go-ipfs-dep/go-ipfs'
 
     mkdirp(npm3Path, (err) => {
-      if (err) console.log(err)
+      if (err) {
+        console.log(err)
+      }
+
       fs.writeFileSync(path.join(npm3Path, 'ipfs'))
       delete require.cache[require.resolve('../lib/node.js')]
       Node = require('../lib/node.js')
@@ -36,7 +39,10 @@ describe('ipfs executable path', function () {
     let npm2Path = '/tmp/ipfsd-ctl-test/node_modules/ipfsd-ctl/node_modules/go-ipfs-dep/go-ipfs'
 
     mkdirp(npm2Path, (err) => {
-      if (err) console.log(err)
+      if (err) {
+        console.log(err)
+      }
+
       fs.writeFileSync(path.join(npm2Path, 'ipfs'))
       delete require.cache[require.resolve('../lib/node.js')]
       Node = require('../lib/node.js')


### PR DESCRIPTION
this pr will fix the problem of ipfsd-ctl not working with npm2. in addition the electron path check is not needed anymore because of the use of __dirname in rootPath.