### PR TITLE
bugfixes and improvements (ipfs daemon flags)

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "license": "MIT",
   "dependencies": {
     "go-ipfs-dep": "0.4.1",
-    "ipfs-api": "^4.1.0",
+    "ipfs-api": "^9.0.0",
     "multiaddr": "^2.0.0",
     "rimraf": "^2.4.5",
     "run-series": "^1.1.4",

--- a/src/node.js
+++ b/src/node.js
@@ -80,7 +80,6 @@ module.exports = class Node {
       done = initOpts
       initOpts = {}
     }
-    let buf = ''
 
     const keySize = initOpts.keysize || 2048
 
@@ -91,9 +90,7 @@ module.exports = class Node {
 
     run(this.exec, ['init', '-b', keySize], {env: this.env})
       .on('error', done)
-      .on('data', (data) => {
-        buf += data
-      })
+      .on('data', () => {}) // let it flow
       .on('end', () => {
         configureNode(this, this.opts, (err) => {
           if (err) return done(err)

--- a/src/node.js
+++ b/src/node.js
@@ -117,18 +117,24 @@ module.exports = class Node {
     }
   }
 
-  startDaemon (done) {
+  startDaemon (flags, done) {
+    if (typeof(flags) === 'function' && typeof(done) === 'undefined') {
+      done = flags
+      flags = []
+    }
+
     const node = this
     parseConfig(node.path, (err, conf) => {
       if (err) return done(err)
 
       let stdout = ""
+      let args = ['daemon'].concat(flags || [])
 
       // strategy:
       // - run subprocess
       // - listen for API addr on stdout (success)
       // - or an early exit or error (failure)
-      node.subprocess = run(node.exec, ['daemon'], {env: node.env})
+      node.subprocess = run(node.exec, args, {env: node.env})
       node.subprocess.on('error', onErr)
         .on('data', onData)
 

--- a/src/node.js
+++ b/src/node.js
@@ -118,7 +118,7 @@ module.exports = class Node {
   }
 
   startDaemon (flags, done) {
-    if (typeof(flags) === 'function' && typeof(done) === 'undefined') {
+    if (typeof flags === 'function' && typeof done === 'undefined') {
       done = flags
       flags = []
     }
@@ -127,7 +127,7 @@ module.exports = class Node {
     parseConfig(node.path, (err, conf) => {
       if (err) return done(err)
 
-      let stdout = ""
+      let stdout = ''
       let args = ['daemon'].concat(flags || [])
 
       // strategy:
@@ -179,7 +179,7 @@ module.exports = class Node {
           node.apiAddr = apiM[1]
         } else {
           // daemon ready but no API server? seems wrong...
-          done2(new Error("daemon ready without api"))
+          done2(new Error('daemon ready without api'))
         }
 
         const gatewayM = stdout.match(/Gateway \((readonly|writable)\) server listening on (.*)\n/)

--- a/src/node.js
+++ b/src/node.js
@@ -151,18 +151,19 @@ module.exports = class Node {
     if (!done) done = () => {}
     if (!this.subprocess) return done(null)
 
-    this.subprocess.kill('SIGTERM')
-
+    // need a local var for the closure, as we clear the var.
+    const subprocess = this.subprocess
     const timeout = setTimeout(() => {
-      this.subprocess.kill('SIGKILL')
+      subprocess.kill('SIGKILL')
       done(null)
     }, GRACE_PERIOD)
 
-    this.subprocess.on('close', () => {
+    subprocess.on('close', () => {
       clearTimeout(timeout)
       done(null)
     })
 
+    subprocess.kill('SIGTERM')
     this.subprocess = null
   }
 

--- a/src/node.js
+++ b/src/node.js
@@ -139,14 +139,14 @@ module.exports = class Node {
         .on('data', onData)
 
       // done2 is called to call done after removing the event listeners
-      function done2 (err, val) {
+      let done2 = (err, val) => {
         node.subprocess.removeListener('data', onData)
         node.subprocess.removeListener('error', onErr)
         if (err) {
           node.killProcess(() => {}) // we failed. kill, just to be sure...
         }
         done(err, val)
-        done = () => {} // in case it gets called twice
+        done2 = () => {} // in case it gets called twice
       }
 
       function onErr (err) {

--- a/src/node.js
+++ b/src/node.js
@@ -109,6 +109,8 @@ module.exports = class Node {
   }
 
   // cleanup tmp files
+  // TODO: this is a bad name for a function. a user may call this expecting
+  // something similar to "stopDaemon()". consider changing it. - @jbenet
   shutdown (done) {
     if (!this.clean && this.disposable) {
       rimraf(this.path, (err) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,7 @@ const ipfsd = require('../src')
 const assert = require('assert')
 const ipfsApi = require('ipfs-api')
 const run = require('subcomandante')
+const bs58 = require('bs58')
 const fs = require('fs')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
@@ -75,21 +76,14 @@ describe('disposable node with local api', function () {
 
   before((done) => {
     const blorb = Buffer('blorb')
-    ipfs.block.put(blorb, (err, res) => {
+    ipfs.block.put(blorb, (err, block) => {
       if (err) throw err
-      store = res.Key
+      store = bs58.encode(block.key).toString()
 
-      ipfs.block.get(res.Key, (err, res) => {
+      ipfs.block.get(store, (err, block) => {
         if (err) throw err
-        let buf = ''
-        res
-          .on('data', (data) => {
-            buf += data
-          })
-          .on('end', () => {
-            retrieve = buf
-            done()
-          })
+        retrieve = block.data
+        done()
       })
     })
   })
@@ -123,21 +117,14 @@ describe('disposableApi node', function () {
 
   before((done) => {
     const blorb = Buffer('blorb')
-    ipfs.block.put(blorb, (err, res) => {
+    ipfs.block.put(blorb, (err, block) => {
       if (err) throw err
-      store = res.Key
+      store = bs58.encode(block.key).toString()
 
-      ipfs.block.get(res.Key, (err, res) => {
+      ipfs.block.get(store, (err, block) => {
         if (err) throw err
-        let buf = ''
-        res
-          .on('data', (data) => {
-            buf += data
-          })
-          .on('end', () => {
-            retrieve = buf
-            done()
-          })
+        retrieve = block.data
+        done()
       })
     })
   })
@@ -360,12 +347,12 @@ describe('ipfs-api version', function () {
 
   // NOTE: if you change ../src/, the hash will need to be changed
   it('uses the correct ipfs-api', (done) => {
-    ipfs.add(path.join(__dirname, '../src'), { recursive: true }, (err, res) => {
+    ipfs.util.addFromFs(path.join(__dirname, '../src'), { recursive: true }, (err, res) => {
       if (err) throw err
 
       const added = res[res.length - 1]
       assert(added)
-      assert.equal(added.Hash, 'QmcECcejtuFh54aAYZTHoyAWEKHBg9xFc1i943UmxRBZQq')
+      assert.equal(added.hash, 'QmatJh68V8sNqHujiJe9Bbz9jwaM4TFiER9qqWtFoyBKic')
       done()
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -352,7 +352,7 @@ describe('ipfs-api version', function () {
 
       const added = res[res.length - 1]
       assert(added)
-      assert.equal(added.hash, 'QmatJh68V8sNqHujiJe9Bbz9jwaM4TFiER9qqWtFoyBKic')
+      assert.equal(added.hash, 'QmUNYnr4nm9Zfr6utTD9rVdSf9ASRguqHDciwvsc2gsH8y')
       done()
     })
   })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,4 +1,5 @@
 /* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 8] */
 'use strict'
 
 const ipfsd = require('../src')
@@ -374,15 +375,14 @@ describe('node startDaemon', () => {
   it('allows passing flags', (done) => {
     ipfsd.disposable((err, node) => {
       if (err) throw err
-      node.startDaemon(["--should-not-exist"], (err, ignore) => {
+      node.startDaemon(['--should-not-exist'], (err, ignore) => {
         if (!err) {
-          throw new Error("should have errored")
+          throw new Error('should have errored')
         }
 
-        let errStr = "Unrecognized option 'should-not-exist'"
+        let errStr = 'Unrecognized option \'should-not-exist\''
 
-        err = ""+ err
-        if (err.indexOf(errStr) >= 0) {
+        if (String(err).indexOf(errStr) >= 0) {
           done() // correct error
         }
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -369,3 +369,25 @@ describe('ipfs-api version', function () {
     })
   })
 })
+
+describe('node startDaemon', () => {
+  it('allows passing flags', (done) => {
+    ipfsd.disposable((err, node) => {
+      if (err) throw err
+      node.startDaemon(["--should-not-exist"], (err, ignore) => {
+        if (!err) {
+          throw new Error("should have errored")
+        }
+
+        let errStr = "Unrecognized option 'should-not-exist'"
+
+        err = ""+ err
+        if (err.indexOf(errStr) >= 0) {
+          done() // correct error
+        }
+
+        throw err
+      })
+    })
+  })
+})

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -364,7 +364,7 @@ describe('ipfs-api version', function () {
 
       const added = res[res.length - 1]
       assert(added)
-      assert.equal(added.Hash, 'Qmafmh1Cw3H1bwdYpaaj5AbCW4LkYyUWaM7Nykpn5NZoYL')
+      assert.equal(added.Hash, 'QmcECcejtuFh54aAYZTHoyAWEKHBg9xFc1i943UmxRBZQq')
       done()
     })
   })


### PR DESCRIPTION
d74045f (jbenet, 2 minutes ago)
    feat(startDeamon): allow passing flags to ipfs daemon

 9c4dbce (jbenet, 4 minutes ago)
    fix(startDaemon): fix the behavior of startDeamon

    - now waits for "Daemon is ready"
    - also tracks Gateway address
    - checks failures on startup, and returns an error if so
     - this was a serious bug-- would not detect errors.
    - fails correctly, without leaving the process hanging

 b523b1c (jbenet, 7 minutes ago)
    fix: rm unused var (thanks, linter)

 efa2aa4 (jbenet, 10 minutes ago)
    note(shutdown): comment on problematic func name

 d6ad480 (jbenet, 14 minutes ago)
    fix(shutdown): fixed bugs in stopDaemon

    - bug1: local var for the closure (this.subprocess set to null)
    - bug2: order problem: should set .on('close') handler before .kill()

 3c50894 (jbenet, 17 minutes ago)
    fix(tests): don't force changing test when src changes