### PR TITLE
update go-ipfs-dep to v0.4.3-2

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "bl": "^1.1.2",
-    "go-ipfs-dep": "0.4.3-2",
+    "go-ipfs-dep": "0.4.4",
     "ipfs-api": "^9.0.0",
     "multiaddr": "^2.0.3",
     "once": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
   "license": "MIT",
   "dependencies": {
     "bl": "^1.1.2",
-    "go-ipfs-dep": "0.4.3-1",
+    "go-ipfs-dep": "0.4.3-2",
     "ipfs-api": "^9.0.0",
     "multiaddr": "^2.0.3",
     "once": "^1.4.0",


### PR DESCRIPTION
related to https://github.com/diasdavid/go-ipfs-dep/pull/9

this should allow me to debug ipfs-log on windows.

cc @haadcode @dignifiedquire 