### PR TITLE
Fail gracefully when config file is not found

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -46,9 +46,8 @@ function configureNode (node, conf, done) {
 
 // Consistent error handling
 function parseConfig (path, done) {
-  const file = fs.readFileSync(join(path, 'config'))
-
   try {
+    const file = fs.readFileSync(join(path, 'config'))
     const parsed = JSON.parse(file)
     done(null, parsed)
   } catch (err) {


### PR DESCRIPTION
In the case that no config file exists, the error generated by `fs.readFileSync` is uncaught.  This results in the `done` callback not being called.