### PR TITLE
Call 'close' only once when the process is killed

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -231,7 +231,7 @@ module.exports = class Node {
       done()
     }, GRACE_PERIOD)
 
-    subprocess.on('close', () => {
+    subprocess.once('close', () => {
       clearTimeout(timeout)
       this.subprocess = null
       done()


### PR DESCRIPTION
Call close only was in order to avoid double callback when the process is killed.