### PR TITLE
Lingering daemons

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "devDependencies": {
     "aegir": "^9.3.0",
     "chai": "^3.5.0",
-    "is-running": "^2.1.0",
+    "is-running": "1.0.5",
     "mkdirp": "^0.5.1",
     "multihashes": "^0.3.1",
     "pre-commit": "^1.2.2"

--- a/src/exec.js
+++ b/src/exec.js
@@ -9,7 +9,8 @@ function exec (cmd, args, opts, handlers) {
   let result = ''
   let callback
 
-  // Handy method if we just want the result and err returned in a callback
+  // Handy method if we just want the result and err
+  // returned in a callback
   if (typeof handlers === 'function') {
     callback = once(handlers)
     handlers = {

--- a/src/node.js
+++ b/src/node.js
@@ -244,7 +244,6 @@ class Node {
     // need a local var for the closure, as we clear the var.
     const subprocess = this.subprocess
     const timeout = setTimeout(() => {
-      console.log('KILLINg')
       subprocess.kill('SIGKILL')
       callback()
     }, GRACE_PERIOD)


### PR DESCRIPTION
The bug reported by https://github.com/ipfs/js-ipfsd-ctl/issues/143 was introduced with https://github.com/ipfs/js-ipfsd-ctl/commit/a0adc8225164e4edfbe9346cc93c50c3f6bd71c2, I'm still super intrigued how the tests passed the scripts pre-release, but truth is that I'm not being able to get to pass now.

Found a issue with the `psExpect` function where the grace countdown had to be `--grace`, otherwise it would never reach 0.

The test failing is that SIGKILL is not effectively killing the process, however the test here is straight out copy of https://github.com/jbenet/node-subcomandante/blob/master/test/test.js#L73-L97 and I've been tinkering back and forward, making both match and I can't seem to figure out exactly where the issue is coming from.

Going to visit this back tomorrow, otherwise we will revert the commit and release a working version.