### PR TITLE
Add gateway address to the returned IPFS api

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -198,6 +198,7 @@ class Node {
         },
         data: (data) => {
           const match = String(data).trim().match(/API server listening on (.*)/)
+          const gwmatch = String(data).trim().match(/Gateway (.*) listening on (.*)/)
 
           if (match) {
             this.apiAddr = match[1]
@@ -205,6 +206,13 @@ class Node {
             this.api = ipfs(this.apiAddr)
             this.api.apiHost = addr.address
             this.api.apiPort = addr.port
+
+            if (gwmatch) {
+              this.gatewayAddr = gwmatch[2]
+              const addr = multiaddr(this.gatewayAddr).nodeAddress()
+              this.api.gatewayHost = addr.address
+              this.api.gatewayPort = addr.port
+            }
 
             callback(null, this.api)
           }

--- a/src/node.js
+++ b/src/node.js
@@ -197,8 +197,9 @@ class Node {
           }
         },
         data: (data) => {
-          const match = String(data).trim().match(/API server listening on (.*)/)
-          const gwmatch = String(data).trim().match(/Gateway (.*) listening on (.*)/)
+          const str = String(data).trim()
+          const match = str.match(/API server listening on (.*)/)
+          const gwmatch = str.match(/Gateway (.*) listening on (.*)/)
 
           if (match) {
             this.apiAddr = match[1]

--- a/src/node.js
+++ b/src/node.js
@@ -87,10 +87,30 @@ class Node {
     this.clean = true
     this.env = Object.assign({}, process.env, {IPFS_PATH: path})
     this.disposable = disposable
+    this._apiAddr = null
+    this._gatewayAddr = null
 
     if (this.opts.env) {
       Object.assign(this.env, this.opts.env)
     }
+  }
+
+  /**
+   * Get the address of connected IPFS API.
+   *
+   * @returns {Multiaddr}
+   */
+  get apiAddr () {
+    return this._apiAddr
+  }
+
+  /**
+   * Get the address of connected IPFS HTTP Gateway.
+   *
+   * @returns {Multiaddr}
+   */
+  get gatewayAddr () {
+    return this._gatewayAddr
   }
 
   _run (args, opts, callback) {
@@ -202,17 +222,15 @@ class Node {
           const gwmatch = str.match(/Gateway (.*) listening on (.*)/)
 
           if (match) {
-            this.apiAddr = match[1]
-            const addr = multiaddr(this.apiAddr).nodeAddress()
-            this.api = ipfs(this.apiAddr)
-            this.api.apiHost = addr.address
-            this.api.apiPort = addr.port
+            this._apiAddr = multiaddr(match[1])
+            this.api = ipfs(match[1])
+            this.api.apiHost = this.apiAddr.nodeAddress().address
+            this.api.apiPort = this.apiAddr.nodeAddress().port
 
             if (gwmatch) {
-              this.gatewayAddr = gwmatch[2]
-              const addr = multiaddr(this.gatewayAddr).nodeAddress()
-              this.api.gatewayHost = addr.address
-              this.api.gatewayPort = addr.port
+              this._gatewayAddr = multiaddr(gwmatch[2])
+              this.api.gatewayHost = this.gatewayAddr.nodeAddress().address
+              this.api.gatewayPort = this.gatewayAddr.nodeAddress().port
             }
 
             callback(null, this.api)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -425,6 +425,24 @@ describe('daemons', () => {
       ], done)
     })
 
+    it('should have started the daemon and returned an api with gateway host and port', (done) => {
+      let daemon
+      const dir = os.tmpdir() + `/${Math.ceil(Math.random() * 100)}`
+      async.waterfall([
+        (cb) => ipfsd.local(dir, cb),
+        (node, cb) => {
+          daemon = node
+          node.init((err) => cb(err, node))
+        },
+        (node, cb) => node.startDaemon((err) => cb(err, node))
+      ], (err, res) => {
+        expect(err).to.exist
+        expect(res).to.have.property('gatewayHost')
+        expect(res).to.have.property('gatewayPort')
+        daemon.stopDaemon(done)
+      })
+    })
+
     it('allows passing flags', (done) => {
       ipfsd.disposable((err, node) => {
         expect(err).to.not.exist

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -434,9 +434,9 @@ describe('daemons', () => {
           daemon = node
           node.init((err) => cb(err, node))
         },
-        (node, cb) => node.startDaemon((err) => cb(err, node))
+        (node, cb) => node.startDaemon((err, api) => cb(err, api))
       ], (err, res) => {
-        expect(err).to.exist
+        expect(err).to.not.exist
         expect(res).to.have.property('gatewayHost')
         expect(res).to.have.property('gatewayPort')
         daemon.stopDaemon(done)

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -6,6 +6,7 @@ const async = require('async')
 const expect = require('chai').expect
 const ipfsApi = require('ipfs-api')
 const mh = require('multihashes')
+const multiaddr = require('multiaddr')
 const fs = require('fs')
 const rimraf = require('rimraf')
 const mkdirp = require('mkdirp')
@@ -425,7 +426,7 @@ describe('daemons', () => {
       ], done)
     })
 
-    it('should have started the daemon and returned an api with gateway host and port', (done) => {
+    it('starts the daemon and returns valid API and gateway addresses', (done) => {
       let daemon
       const dir = os.tmpdir() + `/${Math.ceil(Math.random() * 100)}`
       async.waterfall([
@@ -437,8 +438,23 @@ describe('daemons', () => {
         (node, cb) => node.startDaemon((err, api) => cb(err, api))
       ], (err, res) => {
         expect(err).to.not.exist
+
+        expect(daemon).to.have.property('apiAddr')
+        expect(daemon).to.have.property('gatewayAddr')
+        expect(daemon.apiAddr).to.be.instanceof(multiaddr)
+        expect(daemon.gatewayAddr).to.be.instanceof(multiaddr)
+        expect(daemon.apiAddr).to.not.equal(null)
+        expect(daemon.gatewayAddr).to.not.equal(null)
+
+        expect(res).to.have.property('apiHost')
+        expect(res).to.have.property('apiPort')
         expect(res).to.have.property('gatewayHost')
         expect(res).to.have.property('gatewayPort')
+        expect(res.apiHost).to.equal('127.0.0.1')
+        expect(res.apiPort).to.equal('5001')
+        expect(res.gatewayHost).to.equal('127.0.0.1')
+        expect(res.gatewayPort).to.equal('8080')
+
         daemon.stopDaemon(done)
       })
     })


### PR DESCRIPTION
This PR will add a properties to get the address the gateway was started at and can be accessed with:

```javascript
ipfs.gatewayHost
ipfs.gatewayPort
```