### PR TITLE
fix: Return node only after go-ipfs daemon is ready

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
   "dependencies": {
     "async": "^2.1.5",
     "go-ipfs-dep": "0.4.7",
-    "ipfs-api": "^12.1.7",
+    "ipfs-api": "^14.0.0",
     "multiaddr": "^2.2.2",
     "once": "^1.4.0",
     "rimraf": "^2.6.1",

--- a/src/node.js
+++ b/src/node.js
@@ -220,19 +220,22 @@ class Node {
           const str = String(data).trim()
           const match = str.match(/API server listening on (.*)/)
           const gwmatch = str.match(/Gateway (.*) listening on (.*)/)
+          const readyMatch = str.match(/Daemon is ready/)
 
           if (match) {
             this._apiAddr = multiaddr(match[1])
             this.api = ipfs(match[1])
             this.api.apiHost = this.apiAddr.nodeAddress().address
             this.api.apiPort = this.apiAddr.nodeAddress().port
+          }
 
-            if (gwmatch) {
-              this._gatewayAddr = multiaddr(gwmatch[2])
-              this.api.gatewayHost = this.gatewayAddr.nodeAddress().address
-              this.api.gatewayPort = this.gatewayAddr.nodeAddress().port
-            }
+          if (gwmatch) {
+            this._gatewayAddr = multiaddr(gwmatch[2])
+            this.api.gatewayHost = this.gatewayAddr.nodeAddress().address
+            this.api.gatewayPort = this.gatewayAddr.nodeAddress().port
+          }
 
+          if (readyMatch) {
             callback(null, this.api)
           }
         }


### PR DESCRIPTION
Testing new ipfsd-ctl with Orbit I found a bug where the node is returned before the gateway address has been received and patched to the returned API. Ie. gatewayAddr was undefined.

This PR changes the callback logic so that we listen for "Daemon is ready" stdout from go-ipfs and only then return. Previously we returned when stdout matched "API listening...".