### PR TITLE
adds test getConfig without key, should get the whole config

### DIFF
--- a/src/node.js
+++ b/src/node.js
@@ -306,7 +306,7 @@ class Node {
   getConfig (key, callback) {
     if (typeof key === 'function') {
       callback = key
-      key = ''
+      key = 'show'
     }
 
     async.waterfall([

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -322,6 +322,14 @@ describe('daemons', () => {
       })
     })
 
+    it('Should return the whole config', (done) => {
+      ipfsNode.getConfig((err, config) => {
+        expect(err).to.not.exist()
+        expect(config).to.exist()
+        done()
+      })
+    })
+
     it('Should set a config value', (done) => {
       async.series([
         (cb) => ipfsNode.setConfig('Bootstrap', 'null', cb),


### PR DESCRIPTION
see https://ipfs.github.io/js-ipfsd-ctl/#nodegetconfig
If no key is passed, the whole config is returned as an object.