### PR TITLE
replaces path to .asar.unpacked if cmd includes .asar/node_modules

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,0 +1,23 @@
+environment:
+  matrix:
+    - nodejs_version: "6"
+    - nodejs_version: "8"
+
+# cache:
+#  - node_modules
+
+platform:
+  - x64
+
+install:
+  - ps: Install-Product node $env:nodejs_version $env:platform
+  - npm install
+
+test_script:
+  - node --version
+  - npm --version
+  - npm test
+
+build: off
+
+version: "{build}"

--- a/README.md
+++ b/README.md
@@ -50,6 +50,21 @@ If you need want to use an existing ipfs installation you can set `$IPFS_EXEC=/p
 
 For more details see https://ipfs.github.io/js-ipfsd-ctl/.
 
+### Packaging
+
+`ipfsd-ctl` can be packaged in Electron applications, but the ipfs binary
+has to be excluded from asar (Electron Archives),
+[read more about unpack files from asar](https://electron.atom.io/docs/tutorial/application-packaging/#adding-unpacked-files-in-asar-archive).
+`ipfsd-ctl` will try to detect if used from within an `app.asar` archive
+and tries to resolve ipfs from `app.asar.unpacked`. The ipfs binary is part of
+the `go-ipfs-dep` module.
+
+```bash
+electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep
+```
+
+See [electron asar example](https://github.com/ipfs/js-ipfsd-ctl/tree/master/examples/electron-asar/)
+
 ## Contribute
 
 Feel free to join in. All welcome. Open an [issue](https://github.com/ipfs/js-ipfsd-ctl/issues)!

--- a/examples/disposableApi.js
+++ b/examples/disposableApi.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 'use strict'
 
 // Start a disposable node, and get access to the api

--- a/examples/electron-asar/.gitignore
+++ b/examples/electron-asar/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+test-ipfs-app*

--- a/examples/electron-asar/app.js
+++ b/examples/electron-asar/app.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 'use strict'
 
 const { app, ipcMain, BrowserWindow } = require('electron')

--- a/examples/electron-asar/app.js
+++ b/examples/electron-asar/app.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const { app, ipcMain, BrowserWindow } = require('electron')
+const ipfsd = require('ipfsd-ctl')
+
+app.on('ready', () => {
+  const win = new BrowserWindow({
+    title: 'loading'
+  })
+  win.loadURL(`file://${app.getAppPath()}/public/index.html`)
+})
+
+ipcMain.on('start', ({ sender }) => {
+  console.log('starting disposable IPFS')
+  sender.send('message', 'starting disposable IPFS')
+
+  ipfsd.disposableApi((err, ipfs) => {
+    if (err) {
+      sender.send('error', err)
+      throw err
+    }
+    console.log('get id')
+    sender.send('message', 'get id')
+    ipfs.id(function (err, id) {
+      if (err) {
+        sender.send('error', err)
+        throw err
+      }
+      console.log('got id', id)
+      sender.send('id', JSON.stringify(id))
+    })
+  })
+})

--- a/examples/electron-asar/package.json
+++ b/examples/electron-asar/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "test-ipfs-app",
+  "private": true,
+  "main": "./app.js",
+  "dependencies": {
+    "ipfsd-ctl": "thisconnect/js-ipfsd-ctl#asar-unpacked"
+  },
+  "devDependencies": {
+    "electron": "^1.7.6",
+    "electron-packager": "^9.0.0"
+  },
+  "scripts": {
+    "start": "electron .",
+    "package": "electron-packager ./ --overwrite --asar.unpackDir=node_modules/go-ipfs-dep"
+  }
+}

--- a/examples/electron-asar/package.json
+++ b/examples/electron-asar/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "./app.js",
   "dependencies": {
-    "ipfsd-ctl": "thisconnect/js-ipfsd-ctl#asar-unpacked"
+    "ipfsd-ctl": "*"
   },
   "devDependencies": {
     "electron": "^1.7.6",

--- a/examples/electron-asar/public/index.html
+++ b/examples/electron-asar/public/index.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<title>loading</title>
+<button>test ipfs app</button>
+<script>
+const { ipcRenderer } = require('electron')
+
+ipcRenderer.on('message', (event, msg) => appendPre(msg))
+ipcRenderer.on('error', (event, err) => appendPre(err))
+
+document.querySelector('button')
+  .addEventListener('click', () => {
+    ipcRenderer.once('id', (event, id) => appendPre(id))
+    ipcRenderer.send('start')
+  })
+
+function appendPre(data) {
+  const pre = document.createElement('pre')
+  pre.textContent = data
+  document.body.appendChild(pre)
+}
+</script>

--- a/examples/electron-asar/readme.md
+++ b/examples/electron-asar/readme.md
@@ -1,0 +1,6 @@
+# Packaging
+
+```bash
+npm install
+npm run package
+```

--- a/examples/id.js
+++ b/examples/id.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 'use strict'
 
 var ipfsd = require('../')

--- a/examples/local.js
+++ b/examples/local.js
@@ -1,3 +1,4 @@
+/* eslint no-console: 0 */
 'use strict'
 
 var ipfsd = require('../')

--- a/src/exec.js
+++ b/src/exec.js
@@ -47,15 +47,6 @@ function exec (cmd, args, opts, handlers) {
     })
   }
 
-  // If inside <appname>.asar try to load from .asar.unpacked
-  // this only works if asar was built with
-  // asar --unpack-dir=node_modules/go-ipfs-dep/**
-  // or
-  // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/**
-  if (cmd.includes('.asar/node_modules')) {
-    cmd = cmd.replace('.asar/node_modules', '.asar.unpacked/node_modules')
-  }
-
   const command = run(cmd, args, opts)
 
   if (listeners.data) {

--- a/src/exec.js
+++ b/src/exec.js
@@ -47,6 +47,15 @@ function exec (cmd, args, opts, handlers) {
     })
   }
 
+  // If inside <appname>.asar try to load from .asar.unpacked
+  // this only works if asar was built with
+  // asar --unpack-dir=node_modules/go-ipfs-dep/**
+  // or
+  // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/**
+  if (cmd.includes('.asar/node_modules')) {
+    cmd = cmd.replace('.asar/node_modules', '.asar.unpacked/node_modules')
+  }
+
   const command = run(cmd, args, opts)
 
   if (listeners.data) {

--- a/src/node.js
+++ b/src/node.js
@@ -6,6 +6,7 @@ const ipfs = require('ipfs-api')
 const multiaddr = require('multiaddr')
 const rimraf = require('rimraf')
 const shutdown = require('shutdown')
+const os = require('os')
 const path = require('path')
 const join = path.join
 const once = require('once')

--- a/src/node.js
+++ b/src/node.js
@@ -6,7 +6,6 @@ const ipfs = require('ipfs-api')
 const multiaddr = require('multiaddr')
 const rimraf = require('rimraf')
 const shutdown = require('shutdown')
-const os = require('os')
 const path = require('path')
 const join = path.join
 const once = require('once')
@@ -29,8 +28,7 @@ function findIpfsExecutable () {
   if (appRoot.includes(`.asar${path.sep}`)) {
     appRoot = appRoot.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
   }
-  const ipfsExecutable = os.platform() === 'win32' ? 'ipfs.exe' : 'ipfs'
-  const depPath = path.join('go-ipfs-dep', 'go-ipfs', ipfsExecutable)
+  const depPath = path.join('go-ipfs-dep', 'go-ipfs', 'ipfs')
   const npm3Path = path.join(appRoot, '../', depPath)
   const npm2Path = path.join(appRoot, 'node_modules', depPath)
 

--- a/src/node.js
+++ b/src/node.js
@@ -26,7 +26,7 @@ function findIpfsExecutable () {
   // asar --unpack-dir=node_modules/go-ipfs-dep/* (not tested)
   // or
   // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/*
-  if ( appRoot.includes(`.asar${path.sep}`) ) {
+  if (appRoot.includes(`.asar${path.sep}`)) {
     appRoot = appRoot.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
   }
   const ipfsExecutable = os.platform() === 'win32' ? 'ipfs.exe' : 'ipfs'

--- a/src/node.js
+++ b/src/node.js
@@ -25,7 +25,7 @@ function findIpfsExecutable () {
   // this only works if asar was built with
   // asar --unpack-dir=node_modules/go-ipfs-dep/* (not tested)
   // or
-  // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/*
+  // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep
   if (appRoot.includes(`.asar${path.sep}`)) {
     appRoot = appRoot.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
   }

--- a/src/node.js
+++ b/src/node.js
@@ -26,7 +26,7 @@ function findIpfsExecutable () {
   // or
   // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/*
   if ( appRoot.includes(`.asar${path.sep}`) ) {
-    appPath = appPath.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
+    appRoot = appRoot.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
   }
   const ipfsExecutable = os.platform() === 'win32' ? 'ipfs.exe' : 'ipfs'
   const depPath = path.join('go-ipfs-dep', 'go-ipfs', ipfsExecutable)

--- a/src/node.js
+++ b/src/node.js
@@ -19,8 +19,17 @@ const GRACE_PERIOD = 7500 // amount of ms to wait before sigkill
 function findIpfsExecutable () {
   const rootPath = process.env.testpath ? process.env.testpath : __dirname
 
-  const appRoot = path.join(rootPath, '..')
-  const depPath = path.join('go-ipfs-dep', 'go-ipfs', 'ipfs')
+  let appRoot = path.join(rootPath, '..')
+  // If inside <appname>.asar try to load from .asar.unpacked
+  // this only works if asar was built with
+  // asar --unpack-dir=node_modules/go-ipfs-dep/* (not tested)
+  // or
+  // electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep/*
+  if ( appRoot.includes(`.asar${path.sep}`) ) {
+    appPath = appPath.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
+  }
+  const ipfsExecutable = os.platform() === 'win32' ? 'ipfs.exe' : 'ipfs'
+  const depPath = path.join('go-ipfs-dep', 'go-ipfs', ipfsExecutable)
   const npm3Path = path.join(appRoot, '../', depPath)
   const npm2Path = path.join(appRoot, 'node_modules', depPath)
 

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -390,17 +390,8 @@ describe('daemons', () => {
         if (err) throw err
 
         const added = res[res.length - 1]
-        expect(res.length).to.equal(2)
-        expect(added).to.have.property('path', 'fixtures')
-        expect(added).to.have.property(
-          'hash',
-          'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU'
-        )
-        expect(res[0]).to.have.property('path', 'fixtures/test.txt')
-        expect(res[0]).to.have.property(
-          'hash',
-          'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
-        )
+
+        // Temporary: Need to see what is going on on windows
         expect(res).to.deep.equal([
           {
             path: 'fixtures/test.txt',
@@ -413,6 +404,18 @@ describe('daemons', () => {
             size: 73
           }
         ])
+
+        expect(res.length).to.equal(2)
+        expect(added).to.have.property('path', 'fixtures')
+        expect(added).to.have.property(
+          'hash',
+          'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU'
+        )
+        expect(res[0]).to.have.property('path', 'fixtures/test.txt')
+        expect(res[0]).to.have.property(
+          'hash',
+          'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
+        )
         done()
       })
     })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -432,40 +432,37 @@ describe('daemons', () => {
   })
 
   describe('startDaemon', () => {
-    // skip on windows
-    // https://github.com/ipfs/js-ipfsd-ctl/pull/155#issuecomment-326983530
-    if (isWindows) it.skip('start and stop')
-    else {
-      it('start and stop', (done) => {
-        const dir = `${os.tmpdir()}/tmp-${Date.now() + '-' + Math.random().toString(36)}`
+    it('start and stop', (done) => {
+      const dir = `${os.tmpdir()}/tmp-${Date.now() + '-' + Math.random().toString(36)}`
 
-        const check = (cb) => {
-          if (fs.existsSync(path.join(dir, 'repo.lock'))) {
-            cb(new Error('repo.lock not removed'))
-          }
-          if (fs.existsSync(path.join(dir, 'api'))) {
-            cb(new Error('api file not removed'))
-          }
-          cb()
+      const check = (cb) => {
+        // skip on windows
+        // https://github.com/ipfs/js-ipfsd-ctl/pull/155#issuecomment-326983530
+        if (!isWindows && fs.existsSync(path.join(dir, 'repo.lock'))) {
+          cb(new Error('repo.lock not removed'))
         }
+        if (fs.existsSync(path.join(dir, 'api'))) {
+          cb(new Error('api file not removed'))
+        }
+        cb()
+      }
 
-        async.waterfall([
-          (cb) => ipfsd.local(dir, cb),
-          (node, cb) => node.init((err) => cb(err, node)),
-          (node, cb) => node.startDaemon((err) => cb(err, node)),
-          (node, cb) => node.stopDaemon(cb),
-          check,
-          (cb) => ipfsd.local(dir, cb),
-          (node, cb) => node.startDaemon((err) => cb(err, node)),
-          (node, cb) => node.stopDaemon(cb),
-          check,
-          (cb) => ipfsd.local(dir, cb),
-          (node, cb) => node.startDaemon((err) => cb(err, node)),
-          (node, cb) => node.stopDaemon(cb),
-          check
-        ], done)
-      })
-    }
+      async.waterfall([
+        (cb) => ipfsd.local(dir, cb),
+        (node, cb) => node.init((err) => cb(err, node)),
+        (node, cb) => node.startDaemon((err) => cb(err, node)),
+        (node, cb) => node.stopDaemon(cb),
+        check,
+        (cb) => ipfsd.local(dir, cb),
+        (node, cb) => node.startDaemon((err) => cb(err, node)),
+        (node, cb) => node.stopDaemon(cb),
+        check,
+        (cb) => ipfsd.local(dir, cb),
+        (node, cb) => node.startDaemon((err) => cb(err, node)),
+        (node, cb) => node.stopDaemon(cb),
+        check
+      ], done)
+    })
 
     it('starts the daemon and returns valid API and gateway addresses', (done) => {
       let daemon

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -438,11 +438,13 @@ describe('daemons', () => {
       const check = (cb) => {
         // skip on windows
         // https://github.com/ipfs/js-ipfsd-ctl/pull/155#issuecomment-326983530
-        if (!isWindows && fs.existsSync(path.join(dir, 'repo.lock'))) {
-          cb(new Error('repo.lock not removed'))
-        }
-        if (fs.existsSync(path.join(dir, 'api'))) {
-          cb(new Error('api file not removed'))
+        if (!isWindows) {
+          if (fs.existsSync(path.join(dir, 'repo.lock'))) {
+            cb(new Error('repo.lock not removed'))
+          }
+          if (fs.existsSync(path.join(dir, 'api'))) {
+            cb(new Error('api file not removed'))
+          }
         }
         cb()
       }

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -384,6 +384,15 @@ describe('daemons', () => {
       })
     })
 
+    // skip on windows for now
+    // https://github.com/ipfs/js-ipfsd-ctl/pull/155#issuecomment-326970190
+    // fails on windows see https://github.com/ipfs/js-ipfs-api/issues/408
+    if (os.platform() === 'win32') {
+      it.skip('uses the correct ipfs-api', (done) => {})
+
+      return // does not continue this test on win
+    }
+
     // NOTE: if you change ./fixtures, the hash will need to be changed
     it('uses the correct ipfs-api', (done) => {
       ipfs.util.addFromFs(path.join(__dirname, 'fixtures/'), { recursive: true }, (err, res) => {

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -37,7 +37,7 @@ describe('ipfs executable path', () => {
       Node = require('../src/node.js')
       var node = new Node()
       expect(node.exec)
-        .to.eql('/tmp/ipfsd-ctl-test/node_modules/go-ipfs-dep/go-ipfs/ipfs')
+        .to.eql(path.normalize('/tmp/ipfsd-ctl-test/node_modules/go-ipfs-dep/go-ipfs/ipfs'))
       rimraf('/tmp/ipfsd-ctl-test', done)
     })
   })
@@ -58,7 +58,7 @@ describe('ipfs executable path', () => {
       expect(
         node.exec
       ).to.be.eql(
-        '/tmp/ipfsd-ctl-test/node_modules/ipfsd-ctl/node_modules/go-ipfs-dep/go-ipfs/ipfs'
+        path.normalize('/tmp/ipfsd-ctl-test/node_modules/ipfsd-ctl/node_modules/go-ipfs-dep/go-ipfs/ipfs')
       )
       rimraf('/tmp/ipfsd-ctl-test', done)
     })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -390,9 +390,16 @@ describe('daemons', () => {
         if (err) throw err
 
         const added = res[res.length - 1]
+        expect(res.length).to.equal(2)
+        expect(added).to.have.property('path', 'fixtures')
         expect(added).to.have.property(
           'hash',
           'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU'
+        )
+        expect(res[0]).to.have.property('path', 'fixtures/test.txt')
+        expect(res[0]).to.have.property(
+          'hash',
+          'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
         )
         done()
       })

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -401,6 +401,18 @@ describe('daemons', () => {
           'hash',
           'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
         )
+        expect(res).to.deep.equal([
+          {
+            path: 'fixtures/test.txt',
+            hash: 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD',
+            size: 19
+          },
+          {
+            path: 'fixtures',
+            hash: 'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU',
+            size: 73
+          }
+        ])
         done()
       })
     })


### PR DESCRIPTION
js-ipfsd-ctl will not work inside an asar container, see https://github.com/ipfs/js-ipfsd-ctl/issues/94.

A possible solution is to exclude the ipfs binary from asar, with the unpackDir option

```bash
electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep
```
(EDITED: changed `go-ipfs-dep/**` to `go-ipfs-dep` ) 

on MacOS: this will package everything expect go-ipfs-dep into `<appname>.asar`
and put go-ipfs-dep into `<appname>.asar.unpacked/node_modules/go-ipfs-dep`

This change request adds a check if `.asar/` is part of the path and changes it to `.asar.unpacked/`

Edit:

### How to test this change

Assuming you have a project using ipfsd-ctl, electron and electron-packager. 

Install https://github.com/thisconnect/js-ipfsd-ctl/tree/asar-unpacked
```
npm i thisconnect/js-ipfsd-ctl#asar-unpacked
```
build electron with `--asar.unpackDir=node_modules/go-ipfs-dep`
```
electron-packager ./ --asar.unpackDir=node_modules/go-ipfs-dep
```

Test if your app works and if everything (but go-ipfs-dep) is bundled in an .asar file
