### PR TITLE
tests improves tmp dir

### DIFF
--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -393,7 +393,7 @@ describe('daemons', () => {
 
   describe('startDaemon', () => {
     it('start and stop', (done) => {
-      const dir = os.tmpdir() + `/tmp-${Math.ceil(Math.random() * 100)}`
+      const dir = `${os.tmpdir()}/tmp-${Date.now() + '-' + Math.random().toString(36)}`
 
       const check = (cb) => {
         if (fs.existsSync(path.join(dir, 'repo.lock'))) {
@@ -424,7 +424,7 @@ describe('daemons', () => {
 
     it('starts the daemon and returns valid API and gateway addresses', (done) => {
       let daemon
-      const dir = os.tmpdir() + `/tmp--${Math.ceil(Math.random() * 100)}`
+      const dir = `${os.tmpdir()}/tmp-${Date.now() + '-' + Math.random().toString(36)}`
 
       async.waterfall([
         (cb) => ipfsd.local(dir, cb),


### PR DESCRIPTION
This should fix https://github.com/ipfs/js-ipfsd-ctl/issues/156

This still does **NOT** fix the "occasional" random CI errors 
```
 1) daemons startDaemon starts the daemon and returns valid API and gateway addresses:
     Uncaught AssertionError: expected null to be an instance of Multiaddr
```
as seen here https://travis-ci.org/ipfs/js-ipfsd-ctl/builds/245233174 
or here https://travis-ci.org/ipfs/js-ipfsd-ctl/builds/244451297