### PR TITLE
Smaller key size when testing

### DIFF
--- a/src/daemon-node.js
+++ b/src/daemon-node.js
@@ -106,11 +106,14 @@ class Node {
    * Initialize a repo.
    *
    * @param {Object} [initOpts={}]
-   * @param {number} [initOpts.keysize=2048] - The bit size of the identiy key.
+   * @param {number} [initOpts.keysize=2048] - The bit size of the identity key.
    * @param {string} [initOpts.directory=IPFS_PATH] - The location of the repo.
    * @param {string} [initOpts.pass] - The passphrase of the keychain.
    * @param {function (Error, Node)} callback
    * @returns {undefined}
+   *
+   * If running in a test, then a smaller default keysize is used to
+   * improve speed over security.
    */
   init (initOpts, callback) {
     if (!callback) {
@@ -122,7 +125,16 @@ class Node {
       this.path = initOpts.directory
     }
 
-    const args = ['init', '-b', initOpts.keysize || 2048]
+    let keysize = initOpts.keysize
+    if (!keysize) {
+      if (typeof global.it === 'function') {
+        keysize = this.opts.type === 'go' ? 1024 : 512
+      } else {
+        keysize = 2048
+      }
+    }
+
+    const args = ['init', '-b', keysize]
     if (initOpts.pass) {
       args.push('--pass')
       args.push('"' + initOpts.pass + '"')

--- a/src/in-proc-node.js
+++ b/src/in-proc-node.js
@@ -129,7 +129,7 @@ class Node {
       initOpts = {}
     }
 
-    initOpts.bits = initOpts.keysize || (typeof global.it === 'function') ? 512 : 1024
+    initOpts.bits = initOpts.keysize || (typeof global.it === 'function') ? 512 : 2048
     this.exec.init(initOpts, (err) => {
       if (err) {
         return callback(err)

--- a/src/in-proc-node.js
+++ b/src/in-proc-node.js
@@ -114,11 +114,14 @@ class Node {
    * Initialize a repo.
    *
    * @param {Object} [initOpts={}]
-   * @param {number} [initOpts.keysize=2048] - The bit size of the identiy key.
+   * @param {number} [initOpts.keysize=2048] - The bit size of the identity key.
    * @param {string} [initOpts.directory=IPFS_PATH] - The location of the repo.
    * @param {string} [initOpts.pass] - The passphrase of the keychain.
    * @param {function (Error, Node)} callback
    * @returns {undefined}
+   *
+   * If running in a test, then a smaller default keysize is used to
+   * improve speed over security.
    */
   init (initOpts, callback) {
     if (!callback) {
@@ -126,7 +129,7 @@ class Node {
       initOpts = {}
     }
 
-    initOpts.bits = initOpts.keysize || 2048
+    initOpts.bits = initOpts.keysize || (typeof global.it === 'function') ? 512 : 1024
     this.exec.init(initOpts, (err) => {
       if (err) {
         return callback(err)


### PR DESCRIPTION
A 2048 bit RSA key can take up to 20 seconds to generate.  When testing, a smaller key size can be used.

For `js-ipfs` a 512 bit key size is used.  For `go-ipfs`, because it enforces minimum key size, 1024 bits is used.