### PR TITLE
fix: don't pass on arguments from node executable

### DIFF
--- a/src/utils/run.js
+++ b/src/utils/run.js
@@ -13,5 +13,8 @@ module.exports = (node, args, opts, callback) => {
     executable = process.execPath
   }
 
+  // Don't pass on arguments that were passed into the node executable
+  opts.execArgv = []
+
   return exec(executable, args, opts, callback)
 }


### PR DESCRIPTION
When running a script that involves `ipfsd-ctl` and you pass on
additional parameters it used to pass on those parameters to
the subprocesses it spaws. This lead to issues especially with
`--inspect-brk` as it would spawn another inspector which then
would fail because there is already one running on the same port.

Fixes #202.