### PR TITLE
fix: daemon should recognize previously created repos.

### DIFF
--- a/src/endpoint/routes.js
+++ b/src/endpoint/routes.js
@@ -63,8 +63,8 @@ module.exports = (server) => {
         if (err) {
           return reply(boom.badRequest(err))
         }
-
         const id = hat()
+        const initialized = ipfsd.initialized
         nodes[id] = ipfsd
 
         let api = null
@@ -80,7 +80,7 @@ module.exports = (server) => {
           }
         }
 
-        reply({ id: id, api: api })
+        reply({ id: id, api: api, initialized: initialized })
       })
     }
   })

--- a/src/factory-client.js
+++ b/src/factory-client.js
@@ -95,7 +95,13 @@ class FactoryClient {
         const apiAddr = res.body.api ? res.body.api.apiAddr : ''
         const gatewayAddr = res.body.api ? res.body.api.gatewayAddr : ''
 
-        const ipfsd = new DaemonClient(this.baseUrl, res.body.id, apiAddr, gatewayAddr)
+        const ipfsd = new DaemonClient(
+          this.baseUrl,
+          res.body.id,
+          res.body.initialized,
+          apiAddr,
+          gatewayAddr
+        )
 
         callback(null, ipfsd)
       })

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -130,7 +130,7 @@ class FactoryInProc {
     const node = new Node(options)
 
     series([
-      (cb) => node.exec.once('ready', cb),
+      (cb) => node.once('ready', cb),
       (cb) => node.repo._isInitialized(err => {
         // if err exists, repo failed to find config or the ipfs-repo package
         // version is different than that of the existing repo.

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -131,18 +131,12 @@ class FactoryInProc {
 
     series([
       (cb) => node.exec.once('ready', cb),
-      (cb) => {
-        try {
-          node.repo._isInitialized(() => {
-            node.initialized = true
-            cb()
-          })
-        } catch (err) {
-          // errors if not initialized
-          node.initialized = false
-          cb()
-        }
-      },
+      (cb) => node.repo._isInitialized(err => {
+        // if err exists, repo failed to find config or the ipfs-repo package
+        // version is different than that of the existing repo.
+        node.initialized = !err
+        cb()
+      }),
       (cb) => options.init
         ? node.init(cb)
         : cb(),

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -21,12 +21,12 @@ function createApi (apiAddr, gwAddr) {
 }
 
 class DaemonClient {
-  constructor (baseUrl, _id, apiAddr, gwAddrs) {
+  constructor (baseUrl, _id, initialized, apiAddr, gwAddrs) {
     this.baseUrl = baseUrl
     this._id = _id
     this._apiAddr = multiaddr(apiAddr)
     this._gwAddr = multiaddr(gwAddrs)
-    this.initialized = false
+    this.initialized = initialized
     this.started = false
     this.api = createApi(apiAddr, gwAddrs)
   }

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -52,7 +52,7 @@ class Daemon {
     this.disposable = this.opts.disposable
     this.exec = this.opts.exec || process.env.IPFS_EXEC || findIpfsExecutable(this.opts.type, rootPath)
     this.subprocess = null
-    this.initialized = fs.existsSync(path)
+    this.initialized = fs.existsSync(this.path)
     this.clean = true
     this._apiAddr = null
     this._gatewayAddr = null

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -154,7 +154,7 @@ class Node extends EventEmitter {
         (cb) => this.getConfig(cb),
         (conf, cb) => this.replaceConfig(defaults({}, this.opts.config, conf), cb)
       ], (err) => {
-        if (err) { return callback }
+        if (err) { return callback(err) }
         self.clean = false
         self.initialized = true
         return callback()

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const fs = require('fs')
 const multiaddr = require('multiaddr')
 const defaultsDeep = require('lodash.defaultsdeep')
 const createRepo = require('./utils/repo/create-nodejs')
@@ -33,11 +34,11 @@ class Node extends EventEmitter {
     this.path = this.opts.repoPath
     this.repo = createRepo(this.path)
     this.disposable = this.opts.disposable
+    this.initialized = fs.existsSync(this.path)
     this.clean = true
     this._apiAddr = null
     this._gatewayAddr = null
     this._started = false
-    this.initialized = false
     this.api = null
     this.bits = this.opts.initOptions ? this.opts.initOptions.bits : null
 

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -1,6 +1,5 @@
 'use strict'
 
-const fs = require('fs')
 const multiaddr = require('multiaddr')
 const defaultsDeep = require('lodash.defaultsdeep')
 const createRepo = require('./utils/repo/create-nodejs')
@@ -34,7 +33,6 @@ class Node extends EventEmitter {
     this.path = this.opts.repoPath
     this.repo = createRepo(this.path)
     this.disposable = this.opts.disposable
-    this.initialized = fs.existsSync(this.path)
     this.clean = true
     this._apiAddr = null
     this._gatewayAddr = null

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -138,7 +138,7 @@ describe('Spawn options', function () {
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
 
-            // proc nodes do not reuse initialized repos
+            // proc nodes don't reuse initialized repos
             if (fOpts.type !== 'proc') {
               expect(_ipfsd.initialized).to.eql(true)
             }

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -114,7 +114,7 @@ describe('Spawn options', function () {
         })
       })
 
-      describe('spawn from a initialized repo', () => {
+      describe('spawn from an initialized repo', () => {
         // TODO: figure out why `proc` IPFS refuses
         // to start with a provided repo
         // `Error: Not able to start from state: uninitalized`

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -133,11 +133,11 @@ describe('Spawn options', function () {
           }
 
           f.spawn(options, (err, _ipfsd) => {
-            ipfsd = _ipfsd
             expect(err).to.not.exist()
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
 
+            ipfsd = _ipfsd
             // TODO proc nodes don't reuse initialized repos
             // but they should: https://github.com/ipfs/js-ipfsd-ctl/issues/214
             if (fOpts.type !== 'proc') {

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -133,6 +133,7 @@ describe('Spawn options', function () {
           }
 
           f.spawn(options, (err, _ipfsd) => {
+            ipfsd = _ipfsd
             expect(err).to.not.exist()
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
@@ -142,7 +143,6 @@ describe('Spawn options', function () {
               expect(_ipfsd.initialized).to.eql(true)
             }
 
-            ipfsd = _ipfsd
             done()
           })
         })

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -79,6 +79,7 @@ describe('Spawn options', function () {
             expect(err).to.not.exist()
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
+            expect(_ipfsd.initialized).to.eql(false)
 
             ipfsd = _ipfsd
             repoPath = _ipfsd.repoPath

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -138,7 +138,8 @@ describe('Spawn options', function () {
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
 
-            // proc nodes don't reuse initialized repos
+            // TODO proc nodes don't reuse initialized repos
+            // but they should: https://github.com/ipfs/js-ipfsd-ctl/issues/214
             if (fOpts.type !== 'proc') {
               expect(_ipfsd.initialized).to.eql(true)
             }

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -115,11 +115,6 @@ describe('Spawn options', function () {
       })
 
       describe('spawn from an initialized repo', () => {
-        // TODO: figure out why `proc` IPFS refuses
-        // to start with a provided repo
-        // `Error: Not able to start from state: uninitalized`
-        if (fOpts.type === 'proc') { return }
-
         let ipfsd
 
         it('f.spawn', function (done) {
@@ -135,14 +130,11 @@ describe('Spawn options', function () {
           f.spawn(options, (err, _ipfsd) => {
             expect(err).to.not.exist()
             expect(_ipfsd).to.exist()
-            expect(_ipfsd.api).to.not.exist()
 
             ipfsd = _ipfsd
-            // TODO proc nodes don't reuse initialized repos
-            // but they should: https://github.com/ipfs/js-ipfsd-ctl/issues/214
-            if (fOpts.type !== 'proc') {
-              expect(_ipfsd.initialized).to.eql(true)
-            }
+
+            expect(ipfsd.api).to.not.exist()
+            expect(ipfsd.initialized).to.eql(true)
 
             done()
           })

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -137,6 +137,11 @@ describe('Spawn options', function () {
             expect(_ipfsd).to.exist()
             expect(_ipfsd.api).to.not.exist()
 
+            // proc nodes do not reuse initialized repos
+            if (fOpts.type !== 'proc') {
+              expect(_ipfsd.initialized).to.eql(true)
+            }
+
             ipfsd = _ipfsd
             done()
           })


### PR DESCRIPTION
While working on some go/js interop tests I noticed that a daemon spawned on an already-initialized repo doesn't report itself as initialized.

It turned out to be just a typo so I fixed that and added a test.

**Update**

This PR has four fixes related to `proc` node startup:
- `proc` nodes error when reporting their version: [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-5518d51550f18454b1bdcfed570fbbbcR71)
- `proc` nodes spawn before their IPFS instance has finished booting: [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-5518d51550f18454b1bdcfed570fbbbcR138)
- `proc` nodes do not report themselves as initialized: [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-5518d51550f18454b1bdcfed570fbbbcR139)
- daemons spawned remotely do not report themselves as initialized. [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-b80286715c124db882e2120d455d9ba2R83), [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-7e2d577bc42f51f61a1b45fc5e0d27ceR98), [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-458a8fab61bacfc05620ac20f2c3d6edR24), [here](https://github.com/ipfs/js-ipfsd-ctl/pull/212/files#diff-a64c691b43b66870588c26e5ceb75ea7R55)
