### PR TITLE
keysize is being ignored

### DIFF
--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -136,8 +136,8 @@ class Daemon {
     // in case we decide to change it at
     // the daemon level in the future
     if (bits) {
-      args.concat(['-b', bits])
-      log(`initializing with keysize: ${bits}`)
+      args.push('-b')
+      args.push(bits)
     }
     if (initOptions.pass) {
       args.push('--pass')


### PR DESCRIPTION
The keysize was not being passed on the command line. 

`args.concat` does not modify the arrays, it creates a new array.

