### PR TITLE
feat: add timeout to stop and killProcess

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,11 +218,11 @@ Start the daemon.
 
 Stop the daemon.
 
-`callback` is a function with the signature `function(err)` callback - function that receives an instance of `Error` on failure. Use timeout to specify the grace period before hard stopping the daemon. Otherwise, a grace period of `10500` will be used for disposable nodes and `10500 * 3` for non disposable nodes.
+`callback` is a function with the signature `function(err)` callback - function that receives an instance of `Error` on failure. Use timeout to specify the grace period in ms before hard stopping the daemon. Otherwise, a grace period of `10500` ms will be used for disposable nodes and `10500 * 3` ms for non disposable nodes.
 
 #### `ipfsd.killProcess([timeout, callback])`
 
-Kill the `ipfs daemon` process. Use timeout to specify the grace period before hard stopping the daemon. Otherwise, a grace period of `10500` will be used for disposable nodes and `10500 * 3` for non disposable nodes.
+Kill the `ipfs daemon` process. Use timeout to specify the grace period in ms before hard stopping the daemon. Otherwise, a grace period of `10500` ms will be used for disposable nodes and `10500 * 3` ms for non disposable nodes.
 
 Note: timeout is ignored for `proc` nodes
 

--- a/README.md
+++ b/README.md
@@ -214,15 +214,17 @@ Start the daemon.
 `callback` is a function with the signature `function(err, ipfsApi)` that receives an instance of `ipfs-api` on success or an instance of `Error` on failure
 
 
-#### `ipfsd.stop([callback])`
+#### `ipfsd.stop([timeout, callback])`
 
 Stop the daemon.
 
-`callback` is a function with the signature `function(err)` callback - function that receives an instance of `Error` on failure
+`callback` is a function with the signature `function(err)` callback - function that receives an instance of `Error` on failure. Use timeout to specify the grace period before hard stopping the daemon. Otherwise, a grace period of `10500` will be used for disposable nodes and `10500 * 3` for non disposable nodes.
 
-#### `ipfsd.killProcess([callback])`
+#### `ipfsd.killProcess([timeout, callback])`
 
-Kill the `ipfs daemon` process.
+Kill the `ipfs daemon` process. Use timeout to specify the grace period before hard stopping the daemon. Otherwise, a grace period of `10500` will be used for disposable nodes and `10500 * 3` for non disposable nodes.
+
+Note: timeout is ignored for `proc` nodes
 
 First a `SIGTERM` is sent, after 10.5 seconds `SIGKILL` is sent if the process hasn't exited yet.
 

--- a/src/endpoint/routes.js
+++ b/src/endpoint/routes.js
@@ -191,7 +191,8 @@ module.exports = (server) => {
     path: '/stop',
     handler: (request, reply) => {
       const id = request.query.id
-      nodes[id].stop((err) => {
+      const timeout = request.payload.timeout
+      nodes[id].stop(timeout, (err) => {
         if (err) {
           return reply(boom.badRequest(err))
         }
@@ -213,7 +214,8 @@ module.exports = (server) => {
     path: '/kill',
     handler: (request, reply) => {
       const id = request.query.id
-      nodes[id].killProcess((err) => {
+      const timeout = request.payload.timeout
+      nodes[id].killProcess(timeout, (err) => {
         if (err) {
           return reply(boom.badRequest(err))
         }

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -148,14 +148,20 @@ class DaemonClient {
   /**
    * Stop the daemon.
    *
+   * @param {integer} - Grace period to wait before force stopping the node
    * @param {function(Error)} [cb]
    * @returns {undefined}
    */
-  stop (cb) {
+  stop (timeout, cb) {
+    if (typeof timeout === 'function') {
+      cb = timeout
+      timeout = null
+    }
+
     cb = cb || (() => {})
     request
       .post(`${this.baseUrl}/stop`)
-      .query({ id: this._id })
+      .query({ id: this._id, timeout })
       .end((err) => {
         if (err) {
           return cb(new Error(err.response.body.message))
@@ -169,17 +175,23 @@ class DaemonClient {
   /**
    * Kill the `ipfs daemon` process.
    *
-   * First `SIGTERM` is sent, after 7.5 seconds `SIGKILL` is sent
+   * First `SIGTERM` is sent, after 10.5 seconds `SIGKILL` is sent
    * if the process hasn't exited yet.
    *
+   * @param {integer} - Grace period to wait before force stopping the node
    * @param {function()} [cb] - Called when the process was killed.
    * @returns {undefined}
    */
-  killProcess (cb) {
+  killProcess (timeout, cb) {
+    if (typeof timeout === 'function') {
+      cb = timeout
+      timeout = null
+    }
+
     cb = cb || (() => {})
     request
       .post(`${this.baseUrl}/kill`)
-      .query({ id: this._id })
+      .query({ id: this._id, timeout })
       .end((err) => {
         if (err) {
           return cb(new Error(err.response.body.message))

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -148,20 +148,21 @@ class DaemonClient {
   /**
    * Stop the daemon.
    *
-   * @param {integer} - Grace period to wait before force stopping the node
+   * @param {integer|undefined} timeout - Grace period to wait before force stopping the node
    * @param {function(Error)} [cb]
    * @returns {undefined}
    */
   stop (timeout, cb) {
     if (typeof timeout === 'function') {
       cb = timeout
-      timeout = null
+      timeout = undefined
     }
 
     cb = cb || (() => {})
     request
       .post(`${this.baseUrl}/stop`)
-      .query({ id: this._id, timeout })
+      .query({ id: this._id })
+      .send({ timeout })
       .end((err) => {
         if (err) {
           return cb(new Error(err.response.body.message))
@@ -178,20 +179,21 @@ class DaemonClient {
    * First `SIGTERM` is sent, after 10.5 seconds `SIGKILL` is sent
    * if the process hasn't exited yet.
    *
-   * @param {integer} - Grace period to wait before force stopping the node
+   * @param {integer|undefined} timeout - Grace period to wait before force stopping the node
    * @param {function()} [cb] - Called when the process was killed.
    * @returns {undefined}
    */
   killProcess (timeout, cb) {
     if (typeof timeout === 'function') {
       cb = timeout
-      timeout = null
+      timeout = undefined
     }
 
     cb = cb || (() => {})
     request
       .post(`${this.baseUrl}/kill`)
-      .query({ id: this._id, timeout })
+      .query({ id: this._id })
+      .send({ timeout })
       .end((err) => {
         if (err) {
           return cb(new Error(err.response.body.message))

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -288,7 +288,7 @@ class Daemon {
   /**
    * Stop the daemon.
    *
-   * @param {integer} - Grace period to wait before force stopping the node
+   * @param {integer|undefined} timeout - Grace period to wait before force stopping the node
    * @param {function(Error)} callback
    * @returns {undefined}
    */
@@ -314,7 +314,7 @@ class Daemon {
    * process.kill(`SIGTERM`) is used.  In either case, if the process
    * does not exit after 10.5 seconds then a `SIGKILL` is used.
    *
-   * @param {integer} - Grace period to wait before force stopping the node
+   * @param {integer|undefined} timeout - Grace period to wait before force stopping the node
    * @param {function()} callback - Called when the process was killed.
    * @returns {undefined}
    */

--- a/test/endpoint/client.js
+++ b/test/endpoint/client.js
@@ -267,6 +267,48 @@ describe('client', () => {
     })
   })
 
+  describe('.stop with timeout', () => {
+    describe('handle valid', () => {
+      after(() => {
+        mock.clearRoutes()
+      })
+
+      it('should handle valid request', (done) => {
+        mock.post('http://localhost:9999/stop', (req) => {
+          expect(req.query.id).to.exist()
+        })
+
+        node.stop(1000, (err) => {
+          expect(err).to.not.exist()
+          done()
+        })
+      })
+    })
+
+    describe('handle invalid', () => {
+      after(() => {
+        mock.clearRoutes()
+      })
+
+      it('should handle invalid request', (done) => {
+        mock.post('http://localhost:9999/stop', () => {
+          const badReq = boom.badRequest()
+          return {
+            status: badReq.output.statusCode,
+            body: {
+              message: badReq.message
+            }
+          }
+        })
+
+        node.stop((err) => {
+          expect(err).to.exist()
+          done()
+        })
+      })
+    })
+  })
+
   describe('.killProcess', () => {
     describe('handle valid', () => {
       after(() => {

--- a/test/endpoint/routes.js
+++ b/test/endpoint/routes.js
@@ -213,7 +213,19 @@ describe('routes', () => {
   })
 
   describe('POST /stop', () => {
-    it('should return 200', (done) => {
+    it('should return 200 without timeout', (done) => {
+      server.inject({
+        method: 'POST',
+        url: `/stop?id=${id}`,
+        headers: { 'content-type': 'application/json' },
+        payload: { id }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+    })
+
+    it('should return 200 with timeout', (done) => {
       server.inject({
         method: 'POST',
         url: `/stop?id=${id}`,
@@ -244,6 +256,18 @@ describe('routes', () => {
         url: `/kill?id=${id}`,
         headers: { 'content-type': 'application/json' },
         payload: { id }
+      }, (res) => {
+        expect(res.statusCode).to.equal(200)
+        done()
+      })
+    })
+
+    it('should return 200 with timeout', (done) => {
+      server.inject({
+        method: 'POST',
+        url: `/kill?id=${id}`,
+        headers: { 'content-type': 'application/json' },
+        payload: { id, timeout: 1000 }
       }, (res) => {
         expect(res.statusCode).to.equal(200)
         done()

--- a/test/endpoint/routes.js
+++ b/test/endpoint/routes.js
@@ -38,9 +38,9 @@ const routes = proxyquire(
           cb(null, api)
         }
 
-        node.stop = (cb) => node.killProcess(cb)
+        node.stop = (timeout, cb) => node.killProcess(timeout, cb)
 
-        node.killProcess = (cb) => {
+        node.killProcess = (timeout, cb) => {
           node.started = false
           cb()
         }
@@ -218,7 +218,7 @@ describe('routes', () => {
         method: 'POST',
         url: `/stop?id=${id}`,
         headers: { 'content-type': 'application/json' },
-        payload: { id }
+        payload: { id, timeout: 1000 }
       }, (res) => {
         expect(res.statusCode).to.equal(200)
         done()

--- a/test/start-stop.node.js
+++ b/test/start-stop.node.js
@@ -211,30 +211,12 @@ tests.forEach((fOpts) => {
         expect(api.id).to.exist()
       })
 
-      it('.stop', function (done) {
-        this.timeout(20 * 1000)
-
-        ipfsd.stop((err) => {
-          expect(err).to.not.exist()
-          let tries = 5
-
-          const interval = setInterval(() => {
-            const running = isrunning(pid)
-            if (!running || tries-- <= 0) {
-              clearInterval(interval)
-              expect(running).to.not.be.ok()
-              stopped = true
-              done()
-            }
-          }, 200)
-        })
-      })
-
       it('.stop with timeout', function (done) {
         this.timeout(15000 + 10) // should not take longer than timeout
         ipfsd.stop(15000, (err) => {
           expect(err).to.not.exist()
-          expect(isrunning(pid)).to.not.be.ok()
+          stopped = !isrunning(pid)
+          expect(stopped).to.be.ok()
           done()
         })
       })

--- a/test/start-stop.node.js
+++ b/test/start-stop.node.js
@@ -230,12 +230,11 @@ tests.forEach((fOpts) => {
         })
       })
 
-
       it('.stop with timeout', function (done) {
-        this.timeout(15000) // should not take longer than timeout
+        this.timeout(15000 + 10) // should not take longer than timeout
         ipfsd.stop(15000, (err) => {
           expect(err).to.not.exist()
-          const running = isrunning(pid)
+          expect(isrunning(pid)).to.not.be.ok()
           done()
         })
       })


### PR DESCRIPTION
Adding a timeout param to `stop` and `killProcess` as well as increasing the default grace timeout for non disposable nodes proposed in https://github.com/ipfs/js-ipfsd-ctl/issues/226#issuecomment-379041502.

> - disposable repos do what they do now when calling stop
> - non disposable repos have a longer timeout by default
> - modify ipfsd.stop to allo passing a timeout that allows the user controlling the behavior

~~_note: don't merge, tests still need work_~~

_this is ready for review_

