### PR TITLE
fix: error event propagation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ yarn.lock
 **/*.log
 test/repo-tests*
 
+.vscode
+.eslintrc
 # Logs
 logs
 *.log

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -130,6 +130,7 @@ class FactoryInProc {
     }
 
     const node = new Node(options)
+    node.once('error', err => callback(err, node))
 
     series([
       (cb) => node.once('ready', cb),

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -73,6 +73,7 @@ class Node extends EventEmitter {
     })
 
     this.exec.once('ready', () => this.emit('ready'))
+    this.exec.once('error', err => this.emit('error', err))
   }
 
   /**

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -72,8 +72,8 @@ class Node extends EventEmitter {
       libp2p: this.opts.libp2p
     })
 
-    this.exec.once('ready', () => this.emit('ready'))
     this.exec.once('error', err => this.emit('error', err))
+    this.exec.once('ready', () => this.emit('ready'))
   }
 
   /**


### PR DESCRIPTION
When using node event emitter error events should always be handled and propagated, i'm doing a fix on ipfs cli related to this issue https://github.com/ipfs/js-ipfs/issues/1180 and couldn't catch errors coming from ipfsd this PR fixes that.