### PR TITLE
chore: upgrade ipfs-api to v21

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "detect-node": "^2.0.3",
     "hapi": "^16.6.2",
     "hat": "0.0.3",
-    "ipfs-api": "^20.0.1",
+    "ipfs-api": "^21.0.0",
     "ipfs-repo": "^0.19.0",
     "joi": "^13.1.2",
     "lodash.clone": "^4.5.0",


### PR DESCRIPTION
I `npm link`'d to ipfs@master and the tests passed