### PR TITLE
chore:test fix exec.node.js tests

### DIFF
--- a/test/exec.node.js
+++ b/test/exec.node.js
@@ -2,7 +2,10 @@
 /* eslint-env mocha */
 'use strict'
 
-const expect = require('chai').expect
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
 const isrunning = require('is-running')
 const cp = require('child_process')
 const path = require('path')
@@ -18,12 +21,12 @@ function token () {
   return Math.random().toString().substr(2)
 }
 
-function psExpect (pid, expect, grace, callback) {
+function psExpect (pid, shouldBeRunning, grace, callback) {
   setTimeout(() => {
     const actual = isrunning(pid)
 
-    if (actual !== expect && grace > 0) {
-      return psExpect(pid, expect, --grace, callback)
+    if (actual !== shouldBeRunning && grace > 0) {
+      return psExpect(pid, shouldBeRunning, --grace, callback)
     }
 
     callback(null, actual)
@@ -66,7 +69,7 @@ function makeCheck (n, done) {
 describe('exec', () => {
   // TODO: skip on windows for now
   // TODO: running under coverage messes up the process hierarchies
-  if (isWindows || process.env['COVERAGE']) {
+  if (isWindows || process.env.COVERAGE) {
     return
   }
 
@@ -100,11 +103,6 @@ describe('exec', () => {
       })
     })
   })
-
-  // Travis and CircleCI don't like the usage of SIGHUP
-  if (process.env.CI) {
-    return
-  }
 
   it('SIGKILL kills survivor', (done) => {
     const check = makeCheck(2, done)

--- a/test/survivor
+++ b/test/survivor
@@ -1,3 +1,3 @@
 #!/bin/sh
-trap "echo 'you cannot kill me!'" SIGHUP SIGINT SIGTERM SIGQUIT SIGPIPE
+trap "echo 'you cannot kill me!'" HUP INT TERM QUIT PIPE
 while true; do sleep 1; done


### PR DESCRIPTION
There was a suite of tests that were being bypassed during CI with the assumption that the CI environment was buggy.  Turns out it was the tests.  They were failing locally for me too.

It was not using the dirty-chai so the expect.to.not.exist was failing.
It was also trying to trap SIG* with bin/sh which does not recognize those signals (dropping the SIG prefix works in sh)

This SIG* trapping was what I think was making CI tests fail so I enabled testing in CI again.

I waited to make this PR till jenkins had run the tests and these ones are now passing (I know others aren't and there is another issue to address those)