### PR TITLE
chore: use require.resolve to find ipfs

### DIFF
--- a/src/utils/find-ipfs-executable.js
+++ b/src/utils/find-ipfs-executable.js
@@ -31,5 +31,11 @@ module.exports = (type, rootPath) => {
     return npm2Path
   }
 
+  try {
+    return require.resolve(depPath)
+  } catch (error) {
+    // ignore the error
+  }
+
   throw new Error('Cannot find the IPFS executable')
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -53,7 +53,7 @@ describe('utils', () => {
         expect(fs.existsSync(execPath)).to.be.ok()
       })
 
-      it('should find go executable', () => {
+      it('should find js executable', () => {
         const execPath = findIpfsExecutable('js', __dirname)
         expect(execPath).to.exist()
         expect(execPath).to.include(path.join('ipfs', 'src', 'cli', 'bin.js'))


### PR DESCRIPTION
If we use `require.resolve` to find the ipfs executable, we don't have to assume anything about the file system (e.g. that a `node_modules` folder exists).  This is useful if you're running a mono-repo and your dependencies have been hoisted, for example.