### PR TITLE
feat: allows a custom IpfsApi constructor to be used

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,10 @@ const f = IPFSFactory.create()
 
 f.spawn(function (err, ipfsd) {
   if (err) { throw err }
-  
+
   ipfsd.api.id(function (err, id) {
     if (err) { throw err }
-    
+
     console.log(id)
     ipfsd.stop()
   })
@@ -73,7 +73,7 @@ server.start((err) => {
 
     ipfsd.api.id(function (err, id) {
       if (err) { throw err }
-      
+
       console.log(id)
       ipfsd.stop(server.stop)
     })
@@ -109,6 +109,7 @@ Install one or both of the following modules:
     - `go` - spawn go-ipfs daemon
     - `js` - spawn js-ipfs daemon
     - `proc` - spawn in-process js-ipfs instance. Needs to be called also with exec. Example: `DaemonFactory.create({type: 'proc', exec: require('ipfs') })`.
+  - `IpfsApi` - A custom IPFS API constructor to use instead of the packaged one
 
 **example:** See [Usage](#usage)
 
@@ -128,7 +129,7 @@ Spawn the daemon
 
 - `callback` - is a function with the signature `function (err, ipfsd)` where:
   - `err` - is the error set if spawning the node is unsuccessful
-  - `ipfsd` - is the daemon controller instance: 
+  - `ipfsd` - is the daemon controller instance:
     - `api` - a property of `ipfsd`, an instance of  [ipfs-api](https://github.com/ipfs/js-ipfs-api) attached to the newly created ipfs node   
 
 **example:** See [Usage](#usage)
@@ -145,12 +146,15 @@ Get the version without spawning a daemon
         - repo - the repo version
         - commit - the commit hash for this version
 
-### Remote endpoint - `const server = `IPFSFactory.createServer([options]) `
+### Remote endpoint - `const server = IPFSFactory.createServer([options])`
 
 `IPFSFactory.createServer` starts a IPFSFactory endpoint.
 
-**example:** 
-```
+- `options` is an optional object the following properties:
+  - `port` - the port to start the server on
+
+**example:**
+```js
 const IPFSFactory = require('ipfsd-ctl')
 
 const server = IPFSFactory.createServer({ port: 12345 })
@@ -187,16 +191,16 @@ Get the current repo path. Returns string.
 #### `ipfsd.started` (getter)
 
 Is the node started. Returns a boolean.
- 
+
 #### `init([initOpts], callback)`
 
-Initialize a repo. 
+Initialize a repo.
 
 `initOpts` (optional) is an object with the following properties:
   - `keysize` (default 2048) - The bit size of the identity key.
   - `directory` (default IPFS_PATH if defined, or ~/.ipfs for go-ipfs and ~/.jsipfs for js-ipfs) - The location of the repo.
   - `pass` (optional) - The passphrase of the key chain.
- 
+
 `callback` is a function with the signature `function (Error, ipfsd)` where `err` is an Error in case something goes wrong and `ipfsd` is the daemon controller instance.
 
 #### `ipfsd.cleanup(callback)`
@@ -248,7 +252,7 @@ Returns the output of an `ipfs config` command. If no `key` is passed, the whole
 
 Set a config value.
 
-`key` - the key of the config entry to change/set 
+`key` - the key of the config entry to change/set
 
 `value` - the config value to change/set
 
@@ -259,13 +263,13 @@ Set a config value.
 Get the version of ipfs
 
 `callback` is a function with the signature `function(err, version)`
-   
+
 ### IPFS HTTP Client  - `ipfsd.api`
 
 An instance of [ipfs-api](https://github.com/ipfs/js-ipfs-api#api) that is used to interact with the daemon.
 
 This instance is returned for each successfully started IPFS daemon, when either `df.spawn({start: true})` (the default) is called, or `ipfsd.start()` is invoked in the case of nodes that were spawned with `df.spawn({start: false})`.
-   
+
 ## ipfsd-ctl environment variables
 
 In additional to the API described in previous sections, `ipfsd-ctl` also supports several environment variables. This are often very useful when running in different environments, such as CI or when doing integration/interop testing.
@@ -281,7 +285,7 @@ Meaning that, environment variables override defaults in the configuration file 
 #### IPFS_JS_EXEC and IPFS_GO_EXEC
 
 An alternative way of specifying the executable path for the `js-ipfs` or `go-ipfs` executable, respectively.
-   
+
 ## Packaging
 
 `ipfsd-ctl` can be packaged in Electron applications, but the ipfs binary has to be excluded from asar (Electron Archives).

--- a/src/factory-client.js
+++ b/src/factory-client.js
@@ -11,21 +11,19 @@ class FactoryClient {
     options = options || {}
     if (!options.host) { options.host = 'localhost' }
     if (!options.port) { options.port = 43134 }
+    if (!options.type) { options.type = 'go' }
     if (typeof options.host === 'number') {
       options.port = options.host
       options.host = 'localhost'
     }
 
     this.options = options
-    this.port = options.port
-    this.host = options.host
-    this.type = options.type || 'go'
 
-    if (this.type === 'proc') {
+    if (options.type === 'proc') {
       throw new Error(`'proc' is not supported in client mode`)
     }
 
-    this.baseUrl = `${options.secure ? 'https://' : 'http://'}${this.host}:${this.port}`
+    this.baseUrl = `${options.secure ? 'https://' : 'http://'}${options.host}:${options.port}`
   }
 
   /**
@@ -63,7 +61,7 @@ class FactoryClient {
       options = undefined
     }
 
-    options = options || { type: this.type }
+    options = options || { type: this.options.type }
 
     request
       .get(`${this.baseUrl}/version`)
@@ -87,7 +85,7 @@ class FactoryClient {
 
     request
       .post(`${this.baseUrl}/spawn`)
-      .send({ options: options, type: this.type })
+      .send({ options: options, type: this.options.type })
       .end((err, res) => {
         if (err) {
           return callback(new Error(err.response ? err.response.body.message : err))

--- a/src/factory-client.js
+++ b/src/factory-client.js
@@ -16,6 +16,7 @@ class FactoryClient {
       options.host = 'localhost'
     }
 
+    this.options = options
     this.port = options.port
     this.host = options.host
     this.type = options.type || 'go'
@@ -100,7 +101,8 @@ class FactoryClient {
           res.body.id,
           res.body.initialized,
           apiAddr,
-          gatewayAddr
+          gatewayAddr,
+          { IpfsApi: this.options.IpfsApi }
         )
 
         callback(null, ipfsd)

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -30,10 +30,7 @@ class FactoryDaemon {
     if (options && options.type === 'proc') {
       throw new Error('This Factory does not know how to spawn in proc nodes')
     }
-    options = Object.assign({}, { type: 'go' }, options)
-    this.options = options
-    this.type = options.type
-    this.exec = options.exec
+    this.options = Object.assign({}, { type: 'go' }, options)
   }
 
   /**
@@ -67,7 +64,7 @@ class FactoryDaemon {
     options = Object.assign(
       { IpfsApi: this.options.IpfsApi },
       options,
-      { type: this.type, exec: this.exec }
+      { type: this.options.type, exec: this.options.exec }
     )
     // TODO: (1) this should check to see if it is looking for Go or JS
     // TODO: (2) This spawns a whole daemon just to get his version? There is
@@ -136,8 +133,8 @@ class FactoryDaemon {
       delete options.config.Addresses
     }
 
-    options.type = this.type
-    options.exec = options.exec || this.exec
+    options.type = this.options.type
+    options.exec = options.exec || this.options.exec
     options.initOptions = defaultsDeep({}, this.options.initOptions, options.initOptions)
 
     const node = new Daemon(options)

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -32,9 +32,11 @@ class FactoryInProc {
    * @return {*}
    */
   constructor (options) {
+    options = options || {}
     if (options.type !== 'proc') {
       throw new Error('This Factory only knows how to create in proc nodes')
     }
+    this.options = options
     this.type = options.type
     this.exec = options.exec
   }

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -37,8 +37,6 @@ class FactoryInProc {
       throw new Error('This Factory only knows how to create in proc nodes')
     }
     this.options = options
-    this.type = options.type
-    this.exec = options.exec
   }
 
   /**
@@ -126,8 +124,8 @@ class FactoryInProc {
       delete options.config.Addresses
     }
 
-    options.type = this.type
-    options.exec = options.exec || this.exec
+    options.type = this.options.type
+    options.exec = options.exec || this.options.exec
 
     if (typeof options.exec !== 'function') {
       return callback(new Error(`'type' proc requires 'exec' to be a coderef`))

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -4,7 +4,7 @@ const request = require('superagent')
 const IpfsApi = require('ipfs-api')
 const multiaddr = require('multiaddr')
 
-function createApi (apiAddr, gwAddr) {
+function createApi (apiAddr, gwAddr, IpfsApi) {
   let api
   if (apiAddr) {
     api = IpfsApi(apiAddr)
@@ -21,14 +21,15 @@ function createApi (apiAddr, gwAddr) {
 }
 
 class DaemonClient {
-  constructor (baseUrl, _id, initialized, apiAddr, gwAddrs) {
+  constructor (baseUrl, _id, initialized, apiAddr, gwAddrs, options) {
+    this.options = options || {}
     this.baseUrl = baseUrl
     this._id = _id
     this._apiAddr = multiaddr(apiAddr)
     this._gwAddr = multiaddr(gwAddrs)
     this.initialized = initialized
     this.started = false
-    this.api = createApi(apiAddr, gwAddrs)
+    this.api = createApi(apiAddr, gwAddrs, this.options.IpfsApi || IpfsApi)
   }
 
   /**
@@ -140,7 +141,7 @@ class DaemonClient {
         const apiAddr = res.body.api ? res.body.api.apiAddr : ''
         const gatewayAddr = res.body.api ? res.body.api.gatewayAddr : ''
 
-        this.api = createApi(apiAddr, gatewayAddr)
+        this.api = createApi(apiAddr, gatewayAddr, this.options.IpfsApi || IpfsApi)
         return cb(null, this.api)
       })
   }

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -156,6 +156,8 @@ class Daemon {
       initOptions = {}
     }
 
+    initOptions = initOptions || {}
+
     if (initOptions.directory && initOptions.directory !== this.path) {
       this.path = initOptions.directory
     }
@@ -229,7 +231,7 @@ class Daemon {
 
     const setApiAddr = (addr) => {
       this._apiAddr = multiaddr(addr)
-      this.api = IpfsApi(addr)
+      this.api = (this.opts.IpfsApi || IpfsApi)(addr)
       this.api.apiHost = this.apiAddr.nodeAddress().address
       this.api.apiPort = this.apiAddr.nodeAddress().port
     }

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -180,8 +180,7 @@ class Node extends EventEmitter {
       return callback()
     }
 
-    repoUtils.removeRepo(this.path)
-    callback()
+    repoUtils.removeRepo(this.path, callback)
   }
 
   /**

--- a/src/utils/repo/browser.js
+++ b/src/utils/repo/browser.js
@@ -3,13 +3,15 @@
 
 const hat = require('hat')
 const Dexie = require('dexie')
+const setImmediate = require('async/setImmediate')
 
 exports.createTempRepoPath = function createTempPathRepo () {
   return '/ipfs-' + hat()
 }
 
-exports.removeRepo = function removeRepo (repoPath) {
+exports.removeRepo = function removeRepo (repoPath, callback) {
   Dexie.delete(repoPath)
+  setImmediate(callback)
 }
 
 exports.repoExists = function repoExists (repoPath, cb) {

--- a/src/utils/repo/nodejs.js
+++ b/src/utils/repo/nodejs.js
@@ -6,15 +6,15 @@ const hat = require('hat')
 const rimraf = require('rimraf')
 const fs = require('fs')
 
-exports.removeRepo = function removeRepo (dir) {
-  try {
-    fs.accessSync(dir)
-  } catch (err) {
-    // Does not exist so all good
-    return
-  }
+exports.removeRepo = function removeRepo (dir, callback) {
+  fs.access(dir, (err) => {
+    if (err) {
+      // Does not exist so all good
+      return callback()
+    }
 
-  return rimraf.sync(dir)
+    rimraf(dir, callback)
+  })
 }
 
 exports.createTempRepoPath = function createTempRepo () {

--- a/test/custom-api.spec.js
+++ b/test/custom-api.spec.js
@@ -1,0 +1,31 @@
+/* eslint-env mocha */
+/* eslint max-nested-callbacks: ["error", 8] */
+'use strict'
+
+const chai = require('chai')
+const dirtyChai = require('dirty-chai')
+const expect = chai.expect
+chai.use(dirtyChai)
+
+const setImmediate = require('async/setImmediate')
+const IpfsFactory = require('../src')
+
+describe('custom API', function () {
+  this.timeout(30 * 1000)
+
+  it('should create a factory with a custom API', done => {
+    const mockApi = { shutdown: cb => setImmediate(() => cb()) }
+
+    const f = IpfsFactory.create({
+      type: 'js',
+      initOptions: { bits: 512 },
+      IpfsApi: () => mockApi
+    })
+
+    f.spawn((err, ipfsd) => {
+      if (err) return done(err)
+      expect(ipfsd.api).to.equal(mockApi)
+      ipfsd.stop(done)
+    })
+  })
+})

--- a/test/custom-api.spec.js
+++ b/test/custom-api.spec.js
@@ -10,7 +10,7 @@ chai.use(dirtyChai)
 const IpfsApi = require('ipfs-api')
 const IpfsFactory = require('../src')
 
-describe.only('custom API', function () {
+describe('custom API', function () {
   this.timeout(30 * 1000)
 
   it('should create a factory with a custom API', done => {

--- a/test/custom-api.spec.js
+++ b/test/custom-api.spec.js
@@ -7,14 +7,14 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const setImmediate = require('async/setImmediate')
+const IpfsApi = require('ipfs-api')
 const IpfsFactory = require('../src')
 
-describe('custom API', function () {
+describe.only('custom API', function () {
   this.timeout(30 * 1000)
 
   it('should create a factory with a custom API', done => {
-    const mockApi = { shutdown: cb => setImmediate(() => cb()) }
+    const mockApi = {}
 
     const f = IpfsFactory.create({
       type: 'js',
@@ -25,6 +25,8 @@ describe('custom API', function () {
     f.spawn((err, ipfsd) => {
       if (err) return done(err)
       expect(ipfsd.api).to.equal(mockApi)
+      // Restore a real API so that the node can be stopped properly
+      ipfsd.api = IpfsApi(ipfsd.apiAddr)
       ipfsd.stop(done)
     })
   })


### PR DESCRIPTION
We decided in https://github.com/ipfs/js-ipfsd-ctl/pull/257 that it would be best to bundle ipfs, ipfs-api and go-ipfs-dep but allow the user to pass their own implementations for "advanced mode" usage aka. us and our tests.

This PR is step 1 and it allows the user to pass an `IpfsApi` constructor to `Factory.create` or `f.spawn`.