### PR TITLE
fix: pass config to ipfs for proc daemon

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -70,7 +70,8 @@ class Node extends EventEmitter {
       start: false,
       pass: this.opts.pass,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
-      libp2p: this.opts.libp2p
+      libp2p: this.opts.libp2p,
+      config: this.opts.config
     })
 
     // TODO: should this be wrapped in a process.nextTick(), for context:

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -242,7 +242,8 @@ describe('Spawn options', function () {
               swarmAddr1
             ],
             API: addr
-          }
+          },
+          Bootstrap: ['/dns4/wss0.bootstrap.libp2p.io/tcp/443/wss/ipfs/QmZMxNdpMkewiVZLMRxaNxUeZpDUb34pWjZ1kZvsd16Zic']
         }
 
         const options = { config: config, initOptions: { bits: fOpts.bits } }
@@ -263,6 +264,14 @@ describe('Spawn options', function () {
             }
             expect(config).to.eql([swarmAddr1])
             // expect(config).to.include(swarmAddr1)
+            cb(null, ipfsd)
+          }),
+          (ipfsd, cb) => ipfsd.getConfig('Bootstrap', (err, bootstrapConfig) => {
+            expect(err).to.not.exist()
+            if (typeof bootstrapConfig === 'string') {
+              bootstrapConfig = JSON.parse(bootstrapConfig)
+            }
+            expect(bootstrapConfig).to.deep.equal(config.Bootstrap)
             cb(null, ipfsd)
           })
         ], (err, ipfsd) => {


### PR DESCRIPTION
`config` was not being passed to the IPFS instance when using the proc daemon. This would make it difficult to prevent an in process js daemon from automatically bootstrapping to discovery servers (the default IPFS behavior).

I am currently using this to test the private network addition to js-ipfs and want to avoid auto connecting to public networks.