### PR TITLE
chore: log stderr from daemon

### DIFF
--- a/src/utils/exec.js
+++ b/src/utils/exec.js
@@ -18,7 +18,10 @@ function exec (cmd, args, opts, handlers, callback) {
 
     handlers = {
       error: callback,
-      data (data) {
+      stdout (data) {
+        result += data
+      },
+      stderr (data) {
         result += data
       },
       done () {
@@ -32,7 +35,7 @@ function exec (cmd, args, opts, handlers, callback) {
 
   // The listeners that will actually be set on the process
   const listeners = {
-    data: handlers.data,
+    data: handlers.stdout,
     error (data) {
       err += data
     },
@@ -58,6 +61,10 @@ function exec (cmd, args, opts, handlers, callback) {
   }
 
   command.stderr.on('data', listeners.error)
+
+  if (handlers.stderr) {
+    command.stderr.on('data', handlers.stderr)
+  }
 
   // If command fails to execute return directly to the handler
   command.on('error', handlers.error)

--- a/test/start-stop.node.js
+++ b/test/start-stop.node.js
@@ -141,7 +141,7 @@ tests.forEach((fOpts) => {
           ipfsd.start(['--should-not-exist'], (err) => {
             expect(err).to.exist()
             expect(err.message)
-              .to.match(/unknown option "should-not-exist"\n/)
+              .to.match(/unknown option "should-not-exist"/)
 
             done()
           })
@@ -253,7 +253,7 @@ tests.forEach((fOpts) => {
           ipfsd.start(['--should-not-exist'], (err) => {
             expect(err).to.exist()
             expect(err.message)
-              .to.match(/unknown option "should-not-exist"\n/)
+              .to.match(/unknown option "should-not-exist"/)
 
             done()
           })


### PR DESCRIPTION
Renames process handlers to stderr, stdout and error to better
capture what they do.

Hooks up stderr handler to data event of daemon's stderr to
log data emitted.

Guards against calling the callback multiple times.