### PR TITLE
feat: log stderr from daemon

### DIFF
--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -66,34 +66,20 @@ describe('ipfsd.api for Daemons', () => {
             recursive: true
           }, (err, res) => {
             expect(err).to.not.exist()
+            expect(res.length).to.equal(4)
 
-            const added = res[res.length - 1]
-
-            // TODO: Temporary: Need to see what is going on on windows
-            expect(res).to.eql([
-              {
-                path: 'fixtures/test.txt',
-                hash: 'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD',
-                size: 19
-              },
-              {
-                path: 'fixtures',
-                hash: 'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU',
-                size: 73
-              }
-            ])
-
-            expect(res.length).to.equal(2)
-            expect(added).to.have.property('path', 'fixtures')
-            expect(added).to.have.property(
+            const fixuresDir = res.find(file => file.path === 'fixtures')
+            expect(fixuresDir).to.have.property(
               'hash',
-              'QmXkiTdnfRJjiQREtF5dWf2X4V9awNHQSn9YGofwVY4qUU'
+              'QmR9731QMXHCjK2EvoQZNhMHVE77tGMbgPFXMWPHztMV4a'
             )
-            expect(res[0]).to.have.property('path', 'fixtures/test.txt')
-            expect(res[0]).to.have.property(
+
+            const testFile = res.find(file => file.path === 'fixtures/test.txt')
+            expect(testFile).to.have.property(
               'hash',
               'Qmf412jQZiuVUtdgnB36FXFX7xg5V6KEbSJ4dpQuhkLyfD'
             )
+
             cb()
           })
         },

--- a/test/fixtures/error.js
+++ b/test/fixtures/error.js
@@ -1,0 +1,3 @@
+'use strict'
+
+throw new Error('Goodbye cruel world!')

--- a/test/fixtures/talky.js
+++ b/test/fixtures/talky.js
@@ -1,0 +1,6 @@
+'use strict'
+
+console.info('hello')
+console.error('world')
+
+process.exit(0)

--- a/test/start-stop.node.js
+++ b/test/start-stop.node.js
@@ -141,7 +141,7 @@ tests.forEach((fOpts) => {
           ipfsd.start(['--should-not-exist'], (err) => {
             expect(err).to.exist()
             expect(err.message)
-              .to.match(/unknown option "should-not-exist"\n/)
+              .to.match(/unknown option "should-not-exist"/)
 
             done()
           })
@@ -253,7 +253,7 @@ tests.forEach((fOpts) => {
           ipfsd.start(['--should-not-exist'], (err) => {
             expect(err).to.exist()
             expect(err.message)
-              .to.match(/unknown option "should-not-exist"\n/)
+              .to.match(/unknown option "should-not-exist"/)
 
             done()
           })


### PR DESCRIPTION
* Renames handlers to stderr and stdout to better reflect what they do.
* Hooks up stderr handler to data event of daemon's stderr to log data emitted.
* Uses the callback to handle process errors instead of an extra error handler.
* Specify stderr and stdout handlers in the method options instead of in a separate argument.
* No longer buffers all command output automatically as it can lead to out of memory errors on long running processes, instead the calling code can choose to receive stdout/stderr or not.
* Does not treat any data emitted on stderr as a reason to judge a process as failed when no stderr handler is passed