### PR TITLE
fix: fall back to path

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "safe-json-parse": "^4.0.0",
     "safe-json-stringify": "^1.1.0",
     "shutdown": "~0.3.0",
-    "stream-http": "^2.8.1",
+    "stream-http": "^3.0.0",
     "superagent": "^3.8.2",
     "which": "^1.3.1"
   },

--- a/package.json
+++ b/package.json
@@ -105,7 +105,10 @@
     "rimraf": "^2.6.2",
     "safe-json-parse": "^4.0.0",
     "safe-json-stringify": "^1.1.0",
-    "superagent": "^3.8.2"
+    "shutdown": "~0.3.0",
+    "stream-http": "^2.8.1",
+    "superagent": "^3.8.2",
+    "which": "^1.3.1"
   },
   "devDependencies": {
     "aegir": "^17.0.0",

--- a/src/utils/find-ipfs-executable.js
+++ b/src/utils/find-ipfs-executable.js
@@ -4,11 +4,17 @@ const fs = require('fs')
 const os = require('os')
 const isWindows = os.platform() === 'win32'
 const path = require('path')
+const which = require('which')
 
 module.exports = (type, rootPath) => {
   const execPath = {
     go: path.join('go-ipfs-dep', 'go-ipfs', isWindows ? 'ipfs.exe' : 'ipfs'),
     js: path.join('ipfs', 'src', 'cli', 'bin.js')
+  }
+
+  const execName = {
+    go: `ipfs${isWindows ? '.exe' : ''}`,
+    js: `jsipfs${isWindows ? '.cmd' : ''}`
   }
 
   let appRoot = rootPath ? path.join(rootPath, '..') : process.cwd()
@@ -20,13 +26,24 @@ module.exports = (type, rootPath) => {
   if (appRoot.includes(`.asar${path.sep}`)) {
     appRoot = appRoot.replace(`.asar${path.sep}`, `.asar.unpacked${path.sep}`)
   }
-  const depPath = execPath[type]
+
+  const result = module.exports.find(appRoot, execPath[type], execName[type])
+
+  if (result) {
+    return result
+  }
+
+  throw new Error('Cannot find the IPFS executable')
+}
+
+module.exports.find = (appRoot, depPath, execName) => {
   const npm3Path = path.join(appRoot, '../', depPath)
   const npm2Path = path.join(appRoot, 'node_modules', depPath)
 
   if (fs.existsSync(npm3Path)) {
     return npm3Path
   }
+
   if (fs.existsSync(npm2Path)) {
     return npm2Path
   }
@@ -37,5 +54,9 @@ module.exports = (type, rootPath) => {
     // ignore the error
   }
 
-  throw new Error('Cannot find the IPFS executable')
+  try {
+    return which.sync(execName)
+  } catch (error) {
+    // ignore the error
+  }
 }

--- a/src/utils/find-ipfs-executable.js
+++ b/src/utils/find-ipfs-executable.js
@@ -54,9 +54,5 @@ module.exports.find = (appRoot, depPath, execName) => {
     // ignore the error
   }
 
-  try {
-    return which.sync(execName)
-  } catch (error) {
-    // ignore the error
-  }
+  return which.sync(execName, { nothrow: true })
 }

--- a/src/utils/repo/browser.js
+++ b/src/utils/repo/browser.js
@@ -1,4 +1,3 @@
-/* global self */
 'use strict'
 
 const hat = require('hat')

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -59,6 +59,12 @@ describe('utils', () => {
         expect(execPath).to.include(path.join('ipfs', 'src', 'cli', 'bin.js'))
         expect(fs.existsSync(execPath)).to.be.ok()
       })
+
+      it('should find executable on path', () => {
+        const execName = 'netstat'
+        const execPath = findIpfsExecutable.find('/', '/non-existent-dependency', execName)
+        expect(execPath).to.include(execName)
+      })
     })
   }
 })


### PR DESCRIPTION
When developing features on `ipfs`/`jsipfs` concurrently you usually have your dev versions installed on the path.

To alleviate the tedium of having to type:

```console
$ IPFS_JS_EXEC=`which jsipfs` IPFS_GO_EXEC=`which ipfs` npm test
```

...we could just look on the path for an `ipfs`/`jsipfs` to run.

The PR uses the [`which`](https://www.npmjs.com/package/which) module to attempt to find `ipfs`/`jsipfs` on the path if all other methods fail.