### PR TITLE
fix: add namesys pubsub option

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -57,6 +57,8 @@ class Node extends EventEmitter {
         this.opts.EXPERIMENTAL.pubsub = true
       } else if (arg === '--enable-sharding-experiment') {
         this.opts.EXPERIMENTAL.sharding = true
+      } else if (arg === '--enable-namesys-pubsub') {
+        this.opts.EXPERIMENTAL.ipnsPubsub = true
       } else if (arg.startsWith('--pass')) {
         this.opts.pass = arg.split(' ').slice(1).join(' ')
       } else {


### PR DESCRIPTION
For implementing the tests for `IPNS over Pubsub` on `js-ipfs` using a `type: proc` daemon, we need to have the `--enable-namesys-pubsub` option properly handled. 

Moreover, I cannot add a test for it, similar to the one already available for `--enable-pubsub-experiment`, as it is not available in the last released version of `js-ipfs`. Once this is merged, I will create an Issue for adding those tests and when `IPNS over Pubsub` PR is merged and released, I will get back here for adding the proper test.