### PR TITLE
[WIP] feat: use ipfs-pregen-ids module

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "0.4.17",
     "ipfs": "~0.32.0",
+    "ipfs-pregen-ids": "~0.1.0",
     "is-running": "^2.1.0",
     "mkdirp": "~0.5.1",
     "proxyquire": "^2.0.1",

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -135,7 +135,7 @@ class FactoryDaemon {
 
     options.type = this.options.type
     options.exec = options.exec || this.options.exec
-    options.initOptions = defaultsDeep({}, this.options.initOptions, options.initOptions)
+    options.initOptions = defaultsDeep({_pregen: this.options.pregen}, this.options.initOptions, options.initOptions)
 
     const node = new Daemon(options)
 

--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -147,9 +147,23 @@ class FactoryInProc {
         node.initialized = initialized
         cb()
       }),
-      (cb) => options.init
-        ? node.init(cb)
-        : cb(),
+      (cb) => {
+        if (options.init) {
+          if ((options.disposable || options.pregen) && this.options.pregen) {
+            let id
+            try {
+              id = this.options.pregen(this.options.bits).toString('base64') // if bits not supported by pregen or we're out of pregen ids this throws
+            } catch (e) {
+              // id will be undefined so the arg gets ignored
+            }
+            node.init({privateKey: id}, cb)
+          } else {
+            node.init(cb)
+          }
+        } else {
+          cb()
+        }
+      },
       (cb) => options.start
         ? node.start(options.args, cb)
         : cb()

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,10 @@ const EndpointServer = require('./endpoint/server')
 exports = module.exports
 
 exports.create = (opts) => {
+  if (typeof opts === 'function') { // support .create(require('ipfs-pregen-ids'))
+    opts = {pregen: opts}
+  }
+
   const options = defaults({}, opts, { remote: !isNode })
 
   if (options.type === 'proc') {
@@ -23,7 +27,7 @@ exports.create = (opts) => {
 }
 
 exports.createServer = (options) => {
-  if (typeof options === 'number') {
+  if (typeof options === 'number') { // support .createServer(80)
     options = { port: options }
   }
   return new EndpointServer(options)

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -170,6 +170,13 @@ class Daemon {
     if (bits) {
       args.push('-b')
       args.push(bits)
+    } else if ((this.disposable || initOptions.pregen) && initOptions._pregen) {
+      try {
+        let id = initOptions._pregen(bits).toString('base64') // if bits not supported by pregen or we're out of pregen ids this throws
+        args.push('--private-key', id)
+      } catch (e) {
+        // ignore pregen ids error
+      }
     }
     if (initOptions.pass) {
       args.push('--pass')

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -167,16 +167,20 @@ class Daemon {
     // do not just set a default keysize,
     // in case we decide to change it at
     // the daemon level in the future
-    if (bits) {
-      args.push('-b')
-      args.push(bits)
-    } else if ((this.disposable || initOptions.pregen) && initOptions._pregen) {
+    if ((this.disposable || initOptions.pregen) && initOptions._pregen) {
       try {
         let id = initOptions._pregen(bits).toString('base64') // if bits not supported by pregen or we're out of pregen ids this throws
         args.push('--private-key', id)
       } catch (e) {
         // ignore pregen ids error
+        if (bits) {
+          args.push('-b', bits)
+          args.push(bits)
+        }
       }
+    } else if (bits) {
+      args.push('-b', bits)
+      args.push(bits)
     }
     if (initOptions.pass) {
       args.push('--pass')


### PR DESCRIPTION
This enables usage of the external [`ipfs-pregen-ids`](https://github.com/mkg20001/ipfs-pregen-ids) module and removes the `testIds`

Removes:
 - Automatic pregen id usage for disposable nodes

Adds:
 - `pregen` option to `.create()`
 - Automatic pregen id usage for disposable nodes _only_ if ipfs-pregen-ids module enabled

Todo:
 - [ ] docs
 - [ ] tests
 - [ ] _invite @mkg20001 to ipfs/javascript-team so I can move this module here?_ Make ipfs-pregen-ids an offical module?