### PR TITLE
fix: CLI scraping of API and Gateway addresses

### DIFF
--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -274,8 +274,8 @@ class Daemon {
 
         output += data
 
-        const apiMatch = output.trim().match(/API (?:server|is) listening on[:]? (.*)/)
-        const gwMatch = output.trim().match(/Gateway (?:.*) listening on[:]? (.*)/)
+        const apiMatch = output.trim().match(/API .*listening on:? (.*)/)
+        const gwMatch = output.trim().match(/Gateway .*listening on:? (.*)/)
 
         if (apiMatch && apiMatch.length > 0) {
           setApiAddr(apiMatch[1])


### PR DESCRIPTION
"API is listening..." changed to "API listening..." and no longer matches the regex.

N.B. is backwards compatible with older versions of the daemon.

Required for https://github.com/ipfs/js-ipfs/pull/1595