### PR TITLE
feat: use execa instead of subcomandante

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "debug": "^4.1.0",
     "detect-node": "^2.0.3",
     "dexie": "^2.0.4",
+    "execa": "^1.0.0",
     "hapi": "^16.6.2",
     "hat": "~0.0.3",
     "ipfs-api": "^24.0.1",
@@ -108,7 +109,6 @@
     "rimraf": "^2.6.2",
     "safe-json-parse": "^4.0.0",
     "safe-json-stringify": "^1.1.0",
-    "subcomandante": "^1.0.5",
     "superagent": "^3.8.2"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR swaps subcomandante for execa to execute daemon cmds, `execa` is widely used by the js community, stable, well maintained by a well known js dev, nicer to work with, faster (check benchmarks below).
This will also open the doors for further improvements.
 
- Simple cmd
```
    sub x 6.85 ops/sec ±1.95% (36 runs sampled)
    execa x 13.13 ops/sec ±2.70% (63 runs sampled)
    Fastest is execa
```
- for a full spawn
```js
    const f = IPFSFactory.create()
    
    f.spawn({
    	init: true,
      start: false,
      disposable: true
    }, (err, _ipfsd) => {
      console.log(err)
      defer.resolve()
    })
    sub x 1.36 ops/sec ±29.12% (10 runs sampled)
    execa x 2.82 ops/sec ±12.48% (19 runs sampled)
```
- full tests set went  2m 39s to 2m 14s `-25s`