### PR TITLE
[WIP] docs: add example for non disposable daemons

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ server.start((err) => {
 `ipfsd-ctl` can spawn `disposable` and `non-disposable` daemons.
 
 - `disposable`- Creates on a temporary repo which will be optionally initialized and started (the default), as well cleaned up on process exit. Great for tests.
-- `non-disposable` - Requires the user to initialize and start the node, as well as stop and cleanup after wards. Additionally, a non-disposable will allow you to pass a custom repo using the `repoPath` option, if the `repoPath` is not defined, it will use the default repo for the node type (`$HOME/.ipfs` or `$HOME/.jsipfs`). The `repoPath` parameter is ignored for disposable nodes, as there is a risk of deleting a live repo.
+- `non-disposable` - ipfsd-ctl will initialize and start a daemon if not there isn't a repo initialized and a daemon started. non-disposable defaults to try to find an IPFS repo `$HOME/.ipfs` or `$HOME/.jsipfs` for go-ipfs or js-ipfs respectively. The repo will not be deleted up after use.
 
 ## Batteries not included. Bring your own IPFS executable.
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ npm install --save ipfsd-ctl
 
 ## Usage
 
-**Spawn an IPFS daemon from Node.js**
+**Spawn IPFS daemons from Node.js**
 
 ```js
 // Start a disposable node, and get access to the api
@@ -45,10 +45,24 @@ f.spawn(function (err, ipfsd) {
   ipfsd.api.id(function (err, id) {
     if (err) { throw err }
 
-    console.log(id)
+    console.log('I am an IPFS Daemon', id)
     ipfsd.stop()
   })
 })
+
+// You can do this multiple times!
+
+f.spawn(function (err, ipfsd) {
+  if (err) { throw err }
+
+  ipfsd.api.id(function (err, id) {
+    if (err) { throw err }
+
+    console.log('Another IPFS daemon', id)
+    ipfsd.stop()
+  })
+})
+
 ```
 
 **Spawn an IPFS daemon from the Browser using the provided remote endpoint**
@@ -83,8 +97,8 @@ server.start((err) => {
 
 `ipfsd-ctl` can spawn `disposable` and `non-disposable` daemons.
 
-- `disposable`- Creates on a temporary repo which will be optionally initialized and started (the default), as well cleaned up on process exit. Great for tests.
-- `non-disposable` - ipfsd-ctl will initialize and start a daemon if not there isn't a repo initialized and a daemon started. non-disposable defaults to try to find an IPFS repo `$HOME/.ipfs` or `$HOME/.jsipfs` for go-ipfs or js-ipfs respectively. The repo will not be deleted up after use.
+- `disposable`- Creates on a temporary repo which will be optionally initialized and started (default), as well cleaned up on process exit. Great for writing tests.
+- `Not disposable` - ipfsd-ctl will initialize and start a daemon if not there isn't a repo initialized and a daemon started (if there is, then it will just connect to it). Non Disposable defaults to try to find an IPFS repo `$HOME/.ipfs` or `$HOME/.jsipfs` for go-ipfs or js-ipfs respectively. The repo will not be deleted up after use.
 
 ## Batteries not included. Bring your own IPFS executable.
 
@@ -128,7 +142,7 @@ Spawn the daemon
 - `callback` - is a function with the signature `function (err, ipfsd)` where:
   - `err` - is the error set if spawning the node is unsuccessful
   - `ipfsd` - is the daemon controller instance:
-    - `api` - a property of `ipfsd`, an instance of  [ipfs-api](https://github.com/ipfs/js-ipfs-api) attached to the newly created ipfs node   
+    - `api` - a property of `ipfsd`, an instance of  [ipfs-api](https://github.com/ipfs/js-ipfs-api) attached to the newly created ipfs node
 
 **example:** See [Usage](#usage)
 
@@ -213,7 +227,7 @@ Start the daemon.
 
 `flags` - Flags array to be passed to the `ipfs daemon` command.
 
-`callback` is a function with the signature `function(err, ipfsApi)` that receives an instance of `Error` on failure or an instance of `ipfs-api` on success. 
+`callback` is a function with the signature `function(err, ipfsApi)` that receives an instance of `Error` on failure or an instance of `ipfs-api` on success.
 
 
 #### `ipfsd.stop([timeout, callback])`
@@ -304,11 +318,11 @@ Project structure:
 ```
 src
 ├── defaults
-│   ├── config.json
-│   └── options.json
+│   ├── config.json
+│   └── options.json
 ├── endpoint                    # endpoint to support remote spawning
-│   ├── routes.js
-│   └── server.js
+│   ├── routes.js
+│   └── server.js
 ├── factory-client.js           # IPFS Factories: client (remote), daemon (go or js) and in-proc (js)
 ├── factory-daemon.js
 ├── factory-in-proc.js
@@ -323,8 +337,8 @@ src
     ├── flatten.js
     ├── parse-config.js
     ├── repo
-    │   ├── create-browser.js
-    │   └── create-nodejs.js
+    │   ├── create-browser.js
+    │   └── create-nodejs.js
     ├── run.js
     ├── set-config-value.js
     └── tmp-dir.js

--- a/examples/local-non-disposable/index.js
+++ b/examples/local-non-disposable/index.js
@@ -1,0 +1,48 @@
+/* eslint no-console: 0 */
+'use strict'
+
+// Start a non disposable nodes (default to .ipfs and .jsipfs)
+
+const DaemonFactory = require('ipfsd-ctl')
+
+// start a go daemon
+DaemonFactory
+  .create({ type: 'go' })
+  .spawn({
+    disposable: false
+  }, (err, ipfsd) => {
+    if (err) {
+      throw err
+    }
+
+    ipfsd.api.id((err, id) => {
+      if (err) {
+        throw err
+      }
+
+      console.log('go-ipfs')
+      console.log(id)
+      ipfsd.stop()
+    })
+  })
+
+// start a js daemon
+DaemonFactory
+  .create({ type: 'js' })
+  .spawn({
+    disposable: false
+  }, (err, ipfsd) => {
+    if (err) {
+      throw err
+    }
+
+    ipfsd.api.id((err, id) => {
+      if (err) {
+        throw err
+      }
+
+      console.log('js-ipfs')
+      console.log(id)
+      ipfsd.stop()
+    })
+  })

--- a/examples/local-non-disposable/package.json
+++ b/examples/local-non-disposable/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "local-disposable",
+  "version": "1.0.0",
+  "description": "",
+  "main": "local-disposable.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "dependencies": {
+    "ipfsd-ctl": "file:../.."
+  },
+  "author": "",
+  "license": "MIT"
+}

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -98,8 +98,6 @@ class FactoryDaemon {
 
     if (!options.disposable) {
       const nonDisposableConfig = clone(defaultConfig)
-      options.init = false
-      options.start = false
 
       const defaultRepo = path.join(
         process.env.HOME || process.env.USERPROFILE,
@@ -126,9 +124,14 @@ class FactoryDaemon {
     const node = new Daemon(options)
 
     series([
+
+      // TODO if init fails, check if it was because the
+      // repo was already was inited, if yes, continue
       (cb) => options.init
         ? node.init(options.initOptions, cb)
         : cb(null, node),
+      // TODO if start fails, check if it was because there
+      // is a daemon already running and connect to it instead
       (cb) => options.start
         ? node.start(options.args, cb)
         : cb()

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -124,16 +124,29 @@ class FactoryDaemon {
     const node = new Daemon(options)
 
     series([
-
-      // TODO if init fails, check if it was because the
-      // repo was already was inited, if yes, continue
       (cb) => options.init
-        ? node.init(options.initOptions, cb)
+        ? node.init(options.initOptions, (err) => {
+          if (err) {
+            console.log(err)
+            // TODO if init fails, check if it was because the
+            // repo was already was inited, if yes, continue
+            cb(err)
+          } else {
+            cb()
+          }
+        })
         : cb(null, node),
-      // TODO if start fails, check if it was because there
-      // is a daemon already running and connect to it instead
       (cb) => options.start
-        ? node.start(options.args, cb)
+        ? node.start(options.args, (err) => {
+          if (err) {
+            console.log(err)
+            // TODO if start fails, check if it was because there
+            // is a daemon already running and connect to it instead
+            cb(err)
+          } else {
+            cb()
+          }
+        })
         : cb()
     ], (err) => {
       if (err) { return callback(err) }


### PR DESCRIPTION
The non-disposable daemons option is currently not working. It errors silently.

Steps to reproduce:

- 1. clone this branch, npm install, go to examples/local-non-disposable and run npm install for it to link the main module
- 2. run ipfs init and jsipfs-init
- 3. node index.js

Result

<img width="816" alt="image" src="https://user-images.githubusercontent.com/1211152/47443658-21beb980-d7b5-11e8-956e-07d28c4fe133.png">

It should spawn a go and js daemons on top of .ipfs and .jsipfs respectively and run the .id call without a problem.