### PR TITLE
feat: change to ipfs-http-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Install one or both of the following modules:
     - `go` - spawn go-ipfs daemon
     - `js` - spawn js-ipfs daemon
     - `proc` - spawn in-process js-ipfs instance. Needs to be called also with exec. Example: `DaemonFactory.create({type: 'proc', exec: require('ipfs') })`.
-  - `IpfsApi` - A custom IPFS API constructor to use instead of the packaged one
+  - `IpfsClient` - A custom IPFS API constructor to use instead of the packaged one
 
 **example:** See [Usage](#usage)
 
@@ -128,7 +128,7 @@ Spawn the daemon
 - `callback` - is a function with the signature `function (err, ipfsd)` where:
   - `err` - is the error set if spawning the node is unsuccessful
   - `ipfsd` - is the daemon controller instance:
-    - `api` - a property of `ipfsd`, an instance of  [ipfs-api](https://github.com/ipfs/js-ipfs-api) attached to the newly created ipfs node   
+    - `api` - a property of `ipfsd`, an instance of  [ipfs-http-client](https://github.com/ipfs/js-ipfs-http-client) attached to the newly created ipfs node
 
 **example:** See [Usage](#usage)
 
@@ -213,7 +213,7 @@ Start the daemon.
 
 `flags` - Flags array to be passed to the `ipfs daemon` command.
 
-`callback` is a function with the signature `function(err, ipfsApi)` that receives an instance of `Error` on failure or an instance of `ipfs-api` on success. 
+`callback` is a function with the signature `function(err, ipfsClient)` that receives an instance of `Error` on failure or an instance of `ipfs-http-client` on success.
 
 
 #### `ipfsd.stop([timeout, callback])`
@@ -264,7 +264,7 @@ Get the version of ipfs
 
 ### IPFS HTTP Client  - `ipfsd.api`
 
-An instance of [ipfs-api](https://github.com/ipfs/js-ipfs-api#api) that is used to interact with the daemon.
+An instance of [ipfs-http-client](https://github.com/ipfs/js-ipfs-http-client#api) that is used to interact with the daemon.
 
 This instance is returned for each successfully started IPFS daemon, when either `df.spawn({start: true})` (the default) is called, or `ipfsd.start()` is invoked in the case of nodes that were spawned with `df.spawn({start: false})`.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -12204,6 +12204,7 @@
       "version": "26.1.2",
       "resolved": "https://registry.npmjs.org/ipfs-api/-/ipfs-api-26.1.2.tgz",
       "integrity": "sha512-HkM6vQOHL9z9ZCXIrbDXvAOsIzfWPaAac9kY+SjUuVqMydWHzP8qTxfv5jaXResGbmLcbwcROhuqgJU+HrclSg==",
+      "dev": true,
       "requires": {
         "async": "^2.6.1",
         "big.js": "^5.2.2",
@@ -12294,6 +12295,88 @@
       "dev": true,
       "requires": {
         "async": "^2.6.1"
+      }
+    },
+    "ipfs-http-client": {
+      "version": "27.0.0",
+      "resolved": "https://registry.npmjs.org/ipfs-http-client/-/ipfs-http-client-27.0.0.tgz",
+      "integrity": "sha512-nI12XVXeMm4LU48usmwEgOiw2+byFXppju/U3TFG8u51W5bBP3FslY08t7lKqexPbSFz1+rhYLswJkxV9aQixg==",
+      "requires": {
+        "async": "^2.6.1",
+        "big.js": "^5.2.2",
+        "bl": "^2.1.2",
+        "bs58": "^4.0.1",
+        "cids": "~0.5.5",
+        "concat-stream": "^1.6.2",
+        "debug": "^4.1.0",
+        "detect-node": "^2.0.4",
+        "end-of-stream": "^1.4.1",
+        "flatmap": "0.0.3",
+        "glob": "^7.1.3",
+        "ipfs-block": "~0.8.0",
+        "ipfs-unixfs": "~0.1.16",
+        "ipld-dag-cbor": "~0.13.0",
+        "ipld-dag-pb": "~0.15.0",
+        "is-ipfs": "~0.4.7",
+        "is-pull-stream": "0.0.0",
+        "is-stream": "^1.1.0",
+        "libp2p-crypto": "~0.14.0",
+        "lodash": "^4.17.11",
+        "lru-cache": "^4.1.3",
+        "multiaddr": "^5.0.2",
+        "multibase": "~0.6.0",
+        "multihashes": "~0.4.14",
+        "ndjson": "^1.5.0",
+        "once": "^1.4.0",
+        "peer-id": "~0.12.0",
+        "peer-info": "~0.14.1",
+        "promisify-es6": "^1.0.3",
+        "pull-defer": "~0.2.3",
+        "pull-pushable": "^2.2.0",
+        "pull-stream-to-stream": "^1.3.4",
+        "pump": "^3.0.0",
+        "qs": "^6.5.2",
+        "readable-stream": "^3.0.6",
+        "stream-http": "^3.0.0",
+        "stream-to-pull-stream": "^1.7.2",
+        "streamifier": "~0.1.1",
+        "tar-stream": "^1.6.2",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.4",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.4.tgz",
+          "integrity": "sha512-UYOadoSIkEI/VrRGSG6qp93rp2WdokiAiNYDfGW5qURAY8GiAQkvMbwNNSDYiVJopqv4gCna7xqf4rrNGp+5AA==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        },
+        "ipld-dag-pb": {
+          "version": "0.15.0",
+          "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.15.0.tgz",
+          "integrity": "sha512-rX8kHhiM7975LO6XgSze91TSAEVEpHLsFaLQoR1FLgKoDTwejudRdQJx6DnZmzTT+agpSvi79UYdWTI5ZP+B1w==",
+          "requires": {
+            "async": "^2.6.1",
+            "bs58": "^4.0.1",
+            "cids": "~0.5.4",
+            "class-is": "^1.1.0",
+            "is-ipfs": "~0.4.2",
+            "multihashing-async": "~0.5.1",
+            "protons": "^1.0.1",
+            "pull-stream": "^3.6.9",
+            "pull-traverse": "^1.0.3",
+            "stable": "~0.1.8"
+          }
+        },
+        "multibase": {
+          "version": "0.6.0",
+          "resolved": "https://registry.npmjs.org/multibase/-/multibase-0.6.0.tgz",
+          "integrity": "sha512-R9bNLQhbD7MsitPm1NeY7w9sDgu6d7cuj25snAWH7k5PSNPSwIQQBpcpj8jx1W96dLbdigZqmUWOdQRMnAmgjA==",
+          "requires": {
+            "base-x": "3.0.4"
+          }
+        }
       }
     },
     "ipfs-http-response": {
@@ -12591,6 +12674,7 @@
       "version": "0.14.11",
       "resolved": "https://registry.npmjs.org/ipld-dag-pb/-/ipld-dag-pb-0.14.11.tgz",
       "integrity": "sha512-ja4FH6elDprVuJBkNObFlq7+9h1Q3aoQx5SSG/v3I9e7j19nwyuMhLJYwBhdv29LiqpyD2cEqNrJLm8lWn0lJg==",
+      "dev": true,
       "requires": {
         "async": "^2.6.1",
         "bs58": "^4.0.1",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "execa": "^1.0.0",
     "hapi": "^16.6.2",
     "hat": "~0.0.3",
-    "ipfs-api": "^26.1.0",
+    "ipfs-http-client": "^27.0.0",
     "joi": "^14.0.4",
     "libp2p-crypto": "~0.14.0",
     "lodash.clone": "^4.5.0",

--- a/src/factory-client.js
+++ b/src/factory-client.js
@@ -78,7 +78,7 @@ class FactoryClient {
   }
 
   /**
-   * Spawn a remote daemon using ipfs-api
+   * Spawn a remote daemon using ipfs-http-client
    *
    * @param {SpawnOptions} [options={}]
    * @param {function(Error, DaemonClient)} callback
@@ -109,7 +109,7 @@ class FactoryClient {
           res.body.initialized,
           apiAddr,
           gatewayAddr,
-          { IpfsApi: this.options.IpfsApi }
+          { IpfsClient: this.options.IpfsClient }
         )
 
         callback(null, ipfsd)

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -60,7 +60,7 @@ class FactoryDaemon {
       options = {}
     }
     options = Object.assign(
-      { IpfsApi: this.options.IpfsApi },
+      { IpfsClient: this.options.IpfsClient },
       options,
       { type: this.options.type, exec: this.options.exec }
     )
@@ -75,7 +75,7 @@ class FactoryDaemon {
    * Spawn an IPFS node, either js-ipfs or go-ipfs
    *
    * @param {SpawnOptions} [options={}] - Various config options and ipfs config parameters
-   * @param {function(Error, Daemon): void} callback - Callback receives Error or a Daemon instance, Daemon has a `api` property which is an `ipfs-api` instance.
+   * @param {function(Error, Daemon): void} callback - Callback receives Error or a Daemon instance, Daemon has a `api` property which is an `ipfs-http-client` instance.
    * @returns {void}
    */
   spawn (options, callback) {
@@ -87,7 +87,7 @@ class FactoryDaemon {
     // TODO this options parsing is daunting. Refactor and move to a separate
     // func documenting what it is trying to do.
     options = defaultsDeep(
-      { IpfsApi: this.options.IpfsApi },
+      { IpfsClient: this.options.IpfsClient },
       options,
       defaultOptions
     )

--- a/src/index.js
+++ b/src/index.js
@@ -22,7 +22,7 @@ const Server = require('./endpoint/server')
  * - go - spawn go-ipfs daemon
  * - js - spawn js-ipfs daemon
  * - proc - spawn in-process js-ipfs instance. Needs to be called also with exec. Example: `IPFSFactory.create({type: 'proc', exec: require('ipfs') })`.
- * @param {Object} IpfsApi - A custom IPFS API constructor to use instead of the packaged one `js-ipfs-api`.
+ * @param {Object} IpfsClient - A custom IPFS API constructor to use instead of the packaged one `js-ipfs-http-client`.
  * @returns {(FactoryDaemon|FactoryClient|FactoryInProc)}
  */
 const create = (opts) => {

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -1,13 +1,13 @@
 'use strict'
 
 const request = require('superagent')
-const IpfsApi = require('ipfs-api')
+const IpfsClient = require('ipfs-http-client')
 const multiaddr = require('multiaddr')
 
-function createApi (apiAddr, gwAddr, IpfsApi) {
+function createApi (apiAddr, gwAddr, IpfsClient) {
   let api
   if (apiAddr) {
-    api = IpfsApi(apiAddr)
+    api = IpfsClient(apiAddr)
     api.apiHost = multiaddr(apiAddr).nodeAddress().address
     api.apiPort = multiaddr(apiAddr).nodeAddress().port
   }
@@ -39,7 +39,7 @@ class Client {
     this._gwAddr = multiaddr(gwAddrs)
     this.initialized = initialized
     this.started = false
-    this.api = createApi(apiAddr, gwAddrs, this.options.IpfsApi || IpfsApi)
+    this.api = createApi(apiAddr, gwAddrs, this.options.IpfsClient || IpfsClient)
   }
 
   /**
@@ -128,7 +128,7 @@ class Client {
    * Start the daemon.
    *
    * @param {Array<string>} [flags=[]] - Flags to be passed to the `ipfs daemon` command.
-   * @param {function(Error, IpfsApi)} cb
+   * @param {function(Error, IpfsClient)} cb
    * @returns {undefined}
    */
   start (flags, cb) {
@@ -151,7 +151,7 @@ class Client {
         const apiAddr = res.body.api ? res.body.api.apiAddr : ''
         const gatewayAddr = res.body.api ? res.body.api.gatewayAddr : ''
 
-        this.api = createApi(apiAddr, gatewayAddr, this.options.IpfsApi || IpfsApi)
+        this.api = createApi(apiAddr, gatewayAddr, this.options.IpfsClient || IpfsClient)
         return cb(null, this.api)
       })
   }

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -3,7 +3,7 @@
 const fs = require('fs')
 const waterfall = require('async/waterfall')
 const series = require('async/series')
-const IpfsApi = require('ipfs-api')
+const IpfsClient = require('ipfs-http-client')
 const multiaddr = require('multiaddr')
 const rimraf = require('rimraf')
 const path = require('path')
@@ -73,7 +73,7 @@ class Daemon {
     this._apiAddr = null
     this._gatewayAddr = null
     this._started = false
-    /** @member {IpfsApi} */
+    /** @member {IpfsClient} */
     this.api = null
     this.bits = this.opts.initOptions ? this.opts.initOptions.bits : null
     this._env = Object.assign({}, process.env, this.opts.env)
@@ -210,7 +210,7 @@ class Daemon {
    * Start the daemon.
    *
    * @param {Array<string>} [flags=[]] - Flags to be passed to the `ipfs daemon` command.
-   * @param {function(Error, IpfsApi): void} callback
+   * @param {function(Error, IpfsClient): void} callback
    * @return {void}
    */
   start (flags, callback) {
@@ -228,7 +228,7 @@ class Daemon {
 
     const setApiAddr = (addr) => {
       this._apiAddr = multiaddr(addr)
-      this.api = (this.opts.IpfsApi || IpfsApi)(addr)
+      this.api = (this.opts.IpfsClient || IpfsClient)(addr)
       this.api.apiHost = this.apiAddr.nodeAddress().address
       this.api.apiPort = this.apiAddr.nodeAddress().port
     }

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -187,7 +187,7 @@ class InProc extends EventEmitter {
    * Start the daemon.
    *
    * @param {Array<string>} [flags=[]] - Flags to be passed to the `ipfs daemon` command.
-   * @param {function(Error, IpfsApi)} callback
+   * @param {function(Error, IpfsClient)} callback
    * @returns {undefined}
    */
   start (flags, callback) {

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -62,7 +62,7 @@ describe('ipfsd.api for Daemons', () => {
           })
         },
         (cb) => {
-          api.util.addFromFs(path.join(__dirname, 'fixtures/'), {
+          api.addFromFs(path.join(__dirname, 'fixtures/'), {
             recursive: true
           }, (err, res) => {
             expect(err).to.not.exist()

--- a/test/api.spec.js
+++ b/test/api.spec.js
@@ -107,7 +107,7 @@ describe('ipfsd.api for Daemons', () => {
         expect(ipfsd.gatewayAddr).to.not.be.null()
         expect(multiaddr.isMultiaddr(ipfsd.gatewayAddr)).to.equal(true)
 
-        // Check for props in ipfs-api instance
+        // Check for props in ipfs-http-client instance
         expect(ipfsd.api).to.have.property('apiHost')
         expect(ipfsd.api).to.have.property('apiPort')
         expect(ipfsd.api).to.have.property('gatewayHost')

--- a/test/custom-api.spec.js
+++ b/test/custom-api.spec.js
@@ -7,7 +7,7 @@ const dirtyChai = require('dirty-chai')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const IpfsApi = require('ipfs-api')
+const IpfsClient = require('ipfs-http-client')
 const IpfsFactory = require('../src')
 
 describe('custom API', function () {
@@ -19,14 +19,14 @@ describe('custom API', function () {
     const f = IpfsFactory.create({
       type: 'js',
       initOptions: { bits: 512 },
-      IpfsApi: () => mockApi
+      IpfsClient: () => mockApi
     })
 
     f.spawn((err, ipfsd) => {
       if (err) return done(err)
       expect(ipfsd.api).to.equal(mockApi)
       // Restore a real API so that the node can be stopped properly
-      ipfsd.api = IpfsApi(ipfsd.apiAddr)
+      ipfsd.api = IpfsClient(ipfsd.apiAddr)
       ipfsd.stop(done)
     })
   })


### PR DESCRIPTION
tests still not passing 

```bash
ipfsd.api for Daemons
    go
      1) test the ipfsd.api
(node:2935) UnhandledPromiseRejectionWarning: AssertionError: expected [Error: Command failed: /Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/go-ipfs-dep/go-ipfs/ipfs daemon
Error: serveHTTPApi: manet.Listen(/ip4/127.0.0.1/tcp/5101) failed: listen tcp4 127.0.0.1:5101: bind: address already in use

Initializing daemon...
go-ipfs version: 0.4.18-
Repo version: 7
System version: amd64/darwin
Golang version: go1.11.1
Swarm listening on /ip4/127.0.0.1/tcp/50306
Swarm listening on /p2p-circuit
Swarm announcing /ip4/127.0.0.1/tcp/50306
Received interrupt signal, shutting down...
(Hit ctrl-c again to force-shutdown the daemon.)
] to not exist
    at df.spawn (/Users/hugomrdias/code/pl/js-ipfsd-ctl/test/api.spec.js:99:28)
    at series (/Users/hugomrdias/code/pl/js-ipfsd-ctl/src/factory-daemon.js:136:25)
    at /Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/async/internal/parallel.js:39:9
    at /Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/async/internal/once.js:12:16
    at iterateeCallback (/Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/async/internal/eachOfLimit.js:45:17)
    at /Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/async/internal/onlyOnce.js:12:16
    at /Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/async/internal/parallel.js:36:13
    at f (/Users/hugomrdias/code/pl/js-ipfsd-ctl/node_modules/once/once.js:25:25)
    at command.then.catch.err (/Users/hugomrdias/code/pl/js-ipfsd-ctl/src/utils/exec.js:30:7)
    at process._tickCallback (internal/process/next_tick.js:68:7)

```