### PR TITLE
chore: add local to opts args

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -57,6 +57,8 @@ class InProc extends EventEmitter {
         this.opts.EXPERIMENTAL.ipnsPubsub = true
       } else if (arg === '--enable-dht-experiment') {
         this.opts.EXPERIMENTAL.dht = true
+      } else if (arg === '--local') {
+        this.opts.local = true
       } else if (arg.startsWith('--pass')) {
         this.opts.pass = arg.split(' ').slice(1).join(' ')
       } else {
@@ -69,6 +71,7 @@ class InProc extends EventEmitter {
       init: false,
       start: false,
       pass: this.opts.pass,
+      local: this.opts.local,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
       config: this.opts.config


### PR DESCRIPTION
We need to accept the `local` option for some tests:

https://github.com/ipfs/js-ipfs/blob/master/src/cli/commands/daemon.js#L28