### PR TITLE
fix: rename local flag to offline

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -57,8 +57,8 @@ class InProc extends EventEmitter {
         this.opts.EXPERIMENTAL.ipnsPubsub = true
       } else if (arg === '--enable-dht-experiment') {
         this.opts.EXPERIMENTAL.dht = true
-      } else if (arg === '--local') {
-        this.opts.local = true
+      } else if (arg === '--offline') {
+        this.opts.offline = true
       } else if (arg.startsWith('--pass')) {
         this.opts.pass = arg.split(' ').slice(1).join(' ')
       } else {
@@ -71,7 +71,7 @@ class InProc extends EventEmitter {
       init: false,
       start: false,
       pass: this.opts.pass,
-      local: this.opts.local,
+      offline: this.opts.offline,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
       config: this.opts.config


### PR DESCRIPTION
In the context of https://github.com/ipfs/js-ipfs/issues/1778 and https://github.com/ipfs/js-ipfs/pull/1850 , this is now needed for the tests.

BREAKING CHANGE: `--local` option has been renamed to `--offline`