### PR TITLE
feat: add bundlesize

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -4,6 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
+  bundlesize: '291kB',
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/.aegir.js
+++ b/.aegir.js
@@ -4,7 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
-  bundlesize: '291kB',
+  bundlesize: { maxSize: '291kB' },
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ node_js:
 os:
   - linux
   - osx
-  - windows
 
 script: npx nyc -s npm run test:node -- --bail
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
@@ -20,6 +19,7 @@ jobs:
   include:
     - os: windows
       filter_secrets: false
+      
     - stage: check
       script:
         - npx aegir build --bundlesize

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codeco
 
 jobs:
   include:
+    - os: windows
+      filter_secrets: false
     - stage: check
       script:
         - npx aegir build --bundlesize

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ jobs:
   include:
     - os: windows
       filter_secrets: false
+      cache: false
       
     - stage: check
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ jobs:
   include:
     - stage: check
       script:
+        - npx aegir build --bundlesize
         - npx aegir commitlint --travis
         - npx aegir dep-check
         - npm run lint

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "superagent": "^4.0.0-beta.5"
   },
   "devDependencies": {
-    "aegir": "^18.1.0",
+    "aegir": "ipfs/aegir#feat/bundle-size",
     "chai": "^4.2.0",
     "detect-port": "^1.3.0",
     "dirty-chai": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "superagent": "^4.0.0-beta.5"
   },
   "devDependencies": {
-    "aegir": "ipfs/aegir#feat/bundle-size",
+    "aegir": "^18.2.0",
     "chai": "^4.2.0",
     "detect-port": "^1.3.0",
     "dirty-chai": "^2.0.1",


### PR DESCRIPTION
This PR adds a workaround to the windows secrets problem
```
jobs:
  include:
    - os: windows
      filter_secrets: false
```
because we need to give bundlesize a token but we **should be very careful with this**. 
This disables the log secrets filtering making the token available if you echo the ENV var.
In this case is acceptable because the token only has access to commit_status in this repo.

needs:
[ipfs/aegir#feat/bundle-size](https://github.com/ipfs/aegir/pull/335)