### PR TITLE
fix: pass relay in via opts, not config

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -67,7 +67,8 @@ class InProc extends EventEmitter {
       offline: this.opts.offline,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
-      config: this.opts.config
+      config: this.opts.config,
+      relay: this.opts.relay
     })
 
     // TODO: should this be wrapped in a process.nextTick(), for context:


### PR DESCRIPTION
The latest version of js-ipfs takes `relay` at the first level of options, and not via the `config`. 
https://github.com/ipfs/js-ipfs/tree/v0.34.4#optionsrelay

In the next 0.35 release this will error, as the type checking is more strict.