### PR TITLE
chore: add enable-pubsub flag

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -43,6 +43,8 @@ class InProc extends EventEmitter {
     this.opts.args.forEach((arg) => {
       if (arg === '--enable-pubsub-experiment') {
         this.opts.EXPERIMENTAL.pubsub = true
+      } else if (arg === '--enable-pubsub') {
+        this.opts.pubsub = true
       } else if (arg === '--enable-sharding-experiment') {
         this.opts.EXPERIMENTAL.sharding = true
       } else if (arg === '--enable-namesys-pubsub') {


### PR DESCRIPTION
In the context of [ipfs/js-ipfs#2298#pullrequestreview-280953619](https://github.com/ipfs/js-ipfs/pull/2298#pullrequestreview-280953619), we are moving to `enable-pubsub` instead.