### PR TITLE
fix: pubsub flag defaults

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.22",
     "husky": "^3.0.4",
-    "ipfs": "~0.37.1",
+    "ipfs": "ipfs/js-ipfs#feat/gossipsub-as-default-pubsub",
     "is-running": "^2.1.0",
     "lint-staged": "^9.2.5",
     "proxyquire": "^2.1.3",

--- a/src/endpoint/routes.js
+++ b/src/endpoint/routes.js
@@ -15,7 +15,7 @@ const routeConfig = {
   }
 }
 
-let nodes = {}
+const nodes = {}
 
 /**
  * @namespace EndpointServerRoutes

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -29,7 +29,7 @@ const NON_DISPOSABLE_GRACE_PERIOD = 10500 * 3
 
 function translateError (err) {
   // get the actual error message to be the err.message
-  let message = err.message
+  const message = err.message
   err.message = err.stderr
   err.stderr = message
 
@@ -240,7 +240,7 @@ class Daemon {
 
     let output = ''
 
-    return new Promise(async (resolve, reject) => {
+    return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
       this.subprocess = run(this, args, {
         env: this.env,
         stderr: (data) => {

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -39,12 +39,15 @@ class InProc extends EventEmitter {
       pubsub: false,
       sharding: false
     })
+    this.opts.pubsub = defaultsDeep({}, opts.pubsub, {
+      enabled: false
+    })
 
     this.opts.args.forEach((arg) => {
       if (arg === '--enable-pubsub-experiment') {
         this.opts.EXPERIMENTAL.pubsub = true
       } else if (arg === '--enable-pubsub') {
-        this.opts.pubsub = true
+        this.opts.pubsub.enabled = true
       } else if (arg === '--enable-sharding-experiment') {
         this.opts.EXPERIMENTAL.sharding = true
       } else if (arg === '--enable-namesys-pubsub') {
@@ -68,6 +71,7 @@ class InProc extends EventEmitter {
       offline: this.opts.offline,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
+      pubsub: this.opts.pubsub,
       config: this.opts.config,
       relay: this.opts.relay
     })

--- a/test/npm-install.node.js
+++ b/test/npm-install.node.js
@@ -41,11 +41,11 @@ types.forEach((type) => {
     })
 
     it('has the correct path when installed with npm3', async () => {
-      let execPath = type === 'js'
+      const execPath = type === 'js'
         ? 'ipfsd-ctl-test/node_modules/ipfs/src/cli'
         : 'ipfsd-ctl-test/node_modules/go-ipfs-dep/go-ipfs'
 
-      let npm3Path = path.join(tmp, execPath)
+      const npm3Path = path.join(tmp, execPath)
 
       await fs.mkdirp(npm3Path)
       fs.writeFileSync(path.join(npm3Path, appName))

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -314,7 +314,7 @@ describe('Spawn options', function () {
         this.timeout(20 * 1000)
 
         const options = {
-          args: ['--enable-pubsub-experiment'],
+          args: [fOpts.type !== 'go' ? '--enable-pubsub' : '--enable-pubsub-experiment'],
           initOptions: { bits: fOpts.bits, profile: 'test' }
         }
 
@@ -325,7 +325,7 @@ describe('Spawn options', function () {
         const topic = `test-topic-${hat()}`
         const data = Buffer.from('hey there')
 
-        return new Promise(async (resolve, reject) => {
+        return new Promise(async (resolve, reject) => { // eslint-disable-line no-async-promise-executor
           const handler = (msg) => {
             try {
               expect(msg.data).to.eql(data)


### PR DESCRIPTION
In the context of [ipfs/js-ipfs#2298#pullrequestreview-280953619](https://github.com/ipfs/js-ipfs/pull/2298#pullrequestreview-280953619), we are moving to `enable-pubsub` instead.

`enabled` should be a property of pubsub, in order to allow the usage of other options.

This PR has a circular dependency issue with [ipfs/js-ipfs#2298](https://github.com/ipfs/js-ipfs/pull/2298)