### PR TITLE
chore: update ipfs dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.22",
     "husky": "^3.0.4",
-    "ipfs": "ipfs/js-ipfs#feat/gossipsub-as-default-pubsub",
+    "ipfs": "ipfs/js-ipfs#master",
     "is-running": "^2.1.0",
     "lint-staged": "^9.2.5",
     "proxyquire": "^2.1.3",


### PR DESCRIPTION
With [ipfs/js-ipfs#2298](https://github.com/ipfs/js-ipfs/pull/2298) merged, we can shift this to master until a new release is shipped for `js-ipfs`