### PR TITLE
chore: remove pubsub flags

### DIFF
--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.22",
     "husky": "^3.0.4",
-    "ipfs": "ipfs/js-ipfs#master",
+    "ipfs": "~0.37.1",
     "is-running": "^2.1.0",
     "lint-staged": "^9.2.5",
     "proxyquire": "^2.1.3",

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -36,19 +36,11 @@ class InProc extends EventEmitter {
     this.bits = this.opts.initOptions ? this.opts.initOptions.bits : null
 
     this.opts.EXPERIMENTAL = defaultsDeep({}, opts.EXPERIMENTAL, {
-      pubsub: false,
       sharding: false
-    })
-    this.opts.pubsub = defaultsDeep({}, opts.pubsub, {
-      enabled: false
     })
 
     this.opts.args.forEach((arg) => {
-      if (arg === '--enable-pubsub-experiment') {
-        this.opts.EXPERIMENTAL.pubsub = true
-      } else if (arg === '--enable-pubsub') {
-        this.opts.pubsub.enabled = true
-      } else if (arg === '--enable-sharding-experiment') {
+      if (arg === '--enable-sharding-experiment') {
         this.opts.EXPERIMENTAL.sharding = true
       } else if (arg === '--enable-namesys-pubsub') {
         this.opts.EXPERIMENTAL.ipnsPubsub = true
@@ -71,7 +63,6 @@ class InProc extends EventEmitter {
       offline: this.opts.offline,
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
-      pubsub: this.opts.pubsub,
       config: this.opts.config,
       relay: this.opts.relay
     })

--- a/test/spawn-options.spec.js
+++ b/test/spawn-options.spec.js
@@ -314,7 +314,7 @@ describe('Spawn options', function () {
         this.timeout(20 * 1000)
 
         const options = {
-          args: [fOpts.type !== 'go' ? '--enable-pubsub' : '--enable-pubsub-experiment'],
+          args: ['--enable-namesys-pubsub'],
           initOptions: { bits: fOpts.bits, profile: 'test' }
         }
 


### PR DESCRIPTION
BREAKING CHANGE: pubsub flags for in-proc daemons will not set values anymore

As discussed, we will remove the pubsub flags from the js daemon and will use the config as the way to disable it (will be enabled by default now!)

Ref:

- [ipfs/go-ipfs#6621](https://github.com/ipfs/go-ipfs/issues/6621)
- [ipfs/js-ipfs#2427](https://github.com/ipfs/js-ipfs/pull/2427)