### PR TITLE
feat: init start with one cmd

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,9 +75,11 @@
     "lodash.clone": "^4.5.0",
     "lodash.defaults": "^4.2.0",
     "lodash.defaultsdeep": "^4.6.1",
+    "merge-options": "^1.0.1",
     "multiaddr": "^6.1.0",
     "safe-json-stringify": "^1.2.0",
-    "superagent": "^5.0.5"
+    "superagent": "^5.0.5",
+    "temp-write": "^4.0.0"
   },
   "devDependencies": {
     "aegir": "^20.0.0",
@@ -87,7 +89,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "~0.4.22",
     "husky": "^3.0.4",
-    "ipfs": "~0.37.1",
+    "ipfs": "github:ipfs/js-ipfs#feat/daemon-start-init",
     "is-running": "^2.1.0",
     "lint-staged": "^9.2.5",
     "proxyquire": "^2.1.3",

--- a/src/defaults/options.json
+++ b/src/defaults/options.json
@@ -2,5 +2,6 @@
   "type": "go",
   "disposable": true,
   "start": true,
-  "init": true
+  "init": true,
+  "args": []
 }

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -7,6 +7,7 @@ const tmpDir = require('./utils/tmp-dir')
 const Daemon = require('./ipfsd-daemon')
 const defaultConfig = require('./defaults/config.json')
 const defaultOptions = require('./defaults/options.json')
+const { configFile } = require('./utils/config-file')
 
 /** @ignore @typedef {import("./index").SpawnOptions} SpawnOptions */
 
@@ -112,6 +113,17 @@ class FactoryDaemon {
     options.initOptions = defaultsDeep({}, this.options.initOptions, options.initOptions)
 
     const node = new Daemon(options)
+    if (options.init && options.start && options.type === 'js') {
+      const configPath = configFile(options.type, options.config)
+      const args = options.args.concat([
+        '--init',
+        '--init-config', configPath,
+        '--init-profile', options.initOptions.profile
+      ])
+      await node.start(args)
+
+      return node
+    }
 
     if (options.init) {
       await node.init(options.initOptions)

--- a/src/factory-daemon.js
+++ b/src/factory-daemon.js
@@ -114,7 +114,7 @@ class FactoryDaemon {
 
     const node = new Daemon(options)
     if (options.init && options.start && options.type === 'js') {
-      const configPath = configFile(options.type, options.config)
+      const configPath = await configFile(options.type, options.config)
       const args = options.args.concat([
         '--init',
         '--init-config', configPath,

--- a/src/utils/config-file.js
+++ b/src/utils/config-file.js
@@ -1,0 +1,11 @@
+'use strict'
+const tempWrite = require('temp-write')
+const merge = require('merge-options')
+
+function configFile (type, config) {
+  return tempWrite(JSON.stringify(merge({}, config)), 'config.json')
+}
+
+module.exports = {
+  configFile
+}


### PR DESCRIPTION
ctl timings

before: 

    512 x 0.29 ops/sec ±7.81% (6 runs sampled)
    1024 x 0.30 ops/sec ±3.50% (6 runs sampled)
    2048 x 0.29 ops/sec ±3.97% (6 runs sampled)

after:

    512 x 0.68 ops/sec ±7.11% (8 runs sampled)
    1024 x 0.71 ops/sec ±2.70% (8 runs sampled)
    2048 x 0.69 ops/sec ±3.24% (8 runs sampled)

needs:
https://github.com/ipfs/js-ipfs/pull/2428