### PR TITLE
fix: remove IpfsAPI from in proc node

### DIFF
--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -58,7 +58,6 @@ class FactoryInProc {
     const daemonOptions = merge({
       exec: this.options.exec,
       type: this.options.type,
-      IpfsApi: this.options.IpfsApi,
       disposable: true,
       start: options.disposable !== false,
       init: options.disposable !== false,


### PR DESCRIPTION
An in-proc node doesn't expose any HTTP API and therefore has no use for the http client.