### PR TITLE
fix: support more ipfs options

### DIFF
--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -62,7 +62,11 @@ class InProc {
       EXPERIMENTAL: this.opts.EXPERIMENTAL,
       libp2p: this.opts.libp2p,
       config: this.opts.config,
-      silent: this.opts.silent
+      silent: this.opts.silent,
+      relay: this.opts.relay,
+      preload: this.opts.preload,
+      ipld: this.opts.ipld,
+      connectionManager: this.opts.connectionManager
     })
     return this
   }


### PR DESCRIPTION
in-proc daemon didnt support all the js-ipfs options, this should be improved so we dont need to syncronize manually.

this is related to https://github.com/ipfs/interop/pull/86 circuit tests were failing because relay: true wasnt being passed to the constructor