### PR TITLE
chore: do not call shutdown twice

### DIFF
--- a/src/factory-in-proc.js
+++ b/src/factory-in-proc.js
@@ -70,10 +70,6 @@ class FactoryInProc {
       delete daemonOptions.config.Addresses
     }
 
-    if (typeof daemonOptions.exec !== 'function') {
-      throw new Error('\'type\' proc requires \'exec\' to be a coderef')
-    }
-
     const node = new InProc(daemonOptions)
 
     if (daemonOptions.init) {

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -251,8 +251,7 @@ class Daemon {
     if (!this.subprocess) {
       return this
     }
-    await this.api.stop()
-    // TODO this should call this.api.stop
+
     await this.killProcess(timeout)
 
     if (this.disposable) {


### PR DESCRIPTION
The interface tests in https://github.com/ipfs/js-ipfs-http-client/pull/1183 have started throwing `UnhandledPromiseRejection`s for a connection refused error to `/api/v0/shutdown`. This is because `stop` was being called and then called again in `killProcess`.

With callbacks this error was smothered but it is now appearing with the promise-only API.