### PR TITLE
docs: improve usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ npm install --save ipfsd-ctl
 
 ## Usage
 
-### Spawning a single IPFS daemon: `createController`
+### Spawning a single IPFS controller: `createController`
 
 This is a shorthand for simpler use cases where factory is not needed.
 
 ```js
-// No need to create a factory when only a single node is needed.
+// No need to create a factory when only a single controller is needed.
 // Use createController to spawn it instead.
 const Ctl = require('ipfsd-ctl')
 const ipfsd = await Ctl.createController()
@@ -50,26 +50,25 @@ console.log(id)
 await ipfsd.stop()
 ```
 
-### Spawning multiple IPFS daemons: `createFactory`
+### Manage multiple IPFS controllers: `createFactory`
 
-Use a factory to spawn multiple nodes based on some common template.
+Use a factory to spawn multiple controllers based on some common template.
 
 **Spawn an IPFS daemon from Node.js**
 
 ```js
-// Start two disposable js-ipfs nodes, and get access to apis
-// print node ids, and stop temporary daemons
+// Create a factory to spawn two test disposable controllers, get access to an IPFS api
+// print node ids and clean all the controllers from the factory.
 const Ctl = require('ipfsd-ctl')
-const factory = Ctl.createFactory({ type: 'js', disposable: true })
 
-const ipfsd1 = await factory.spawn()
-const ipfsd2 = await factory.spawn()
+const factory = Ctl.createFactory({ type: 'js', test: true, disposable: true })
+const ipfsd1 = await factory.spawn() // Spawns using options from `createFactory`
+const ipfsd2 = await factory.spawn({ type: 'go' }) // Spawns using options from `createFactory` but overrides `type` to spawn a `go` controller
 
 console.log(await ipfsd1.api.id())
 console.log(await ipfsd2.api.id())
 
-await ipfsd1.stop()
-await ipfsd2.stop()
+await factory.clean() // Clean all the controllers created by the factory calling `stop` on all of them.
 ```
 
 **Spawn an IPFS daemon from the Browser using the provided remote endpoint**

--- a/README.md
+++ b/README.md
@@ -34,20 +34,42 @@ npm install --save ipfsd-ctl
 
 ## Usage
 
-**Spawn an IPFS daemon from Node.js**
+### Spawning a single IPFS daemon: `createController`
+
+This is a shorthand for simpler use cases where factory is not needed.
 
 ```js
-// Start a disposable node, and get access to the api
-// print the node id, and stop the temporary daemon
+// No need to create a factory when only a single node is needed.
+// Use createController to spawn it instead.
 const Ctl = require('ipfsd-ctl')
-const factory = Ctl.createFactory()
-
-const ipfsd = await factory.spawn()
+const ipfsd = await Ctl.createController()
 const id = await ipfsd.api.id()
 
 console.log(id)
 
 await ipfsd.stop()
+```
+
+### Spawning multiple IPFS daemons: `createFactory`
+
+Use a factory to spawn multiple nodes based on some common template.
+
+**Spawn an IPFS daemon from Node.js**
+
+```js
+// Start two disposable js-ipfs nodes, and get access to apis
+// print node ids, and stop temporary daemons
+const Ctl = require('ipfsd-ctl')
+const factory = Ctl.createFactory({ type: 'js', disposable: true })
+
+const ipfsd1 = await factory.spawn()
+const ipfsd2 = await factory.spawn()
+
+console.log(await ipfsd1.api.id())
+console.log(await ipfsd2.api.id())
+
+await ipfsd1.stop()
+await ipfsd2.stop()
 ```
 
 **Spawn an IPFS daemon from the Browser using the provided remote endpoint**
@@ -94,7 +116,7 @@ Creates a controller.
 
 - `options` **[ControllerOptions](#ControllerOptions)** Factory options.
 
-Returns a **[Controller](#Controller)**
+Returns **Promise&lt;[Controller](#controller)>**
 
 ### `createServer([options])`
 Create an Endpoint Server. This server is used by a client node to control a remote node. Example: Spawning a go-ipfs node from a browser.


### PR DESCRIPTION
> This PR addresses problems raised in https://github.com/ipfs-shipyard/ipfs-webui/pull/1353#discussion_r360726012

This PR:

- improves  Usage docs
  - added code example for `createController`
  - improved example for `createFactory` to show the value of shared factory template
- fixed return type of  `createController` in docs