### PR TITLE
fix: remove swarm addrs in browser

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -4,7 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
-  bundlesize: { maxSize: '920kB' },
+  bundlesize: { maxSize: '928kB' },
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/src/config.js
+++ b/src/config.js
@@ -8,6 +8,9 @@ module.exports = ({ type }) => {
   // from the browser tell remote nodes to listen over WS
   if (type !== 'proc' && (isBrowser || isWebWorker)) {
     swarm = ['/ip4/127.0.0.1/tcp/0/ws']
+  // from the browser, in process nodes cannot listen on _any_ addrs
+  } else if (type === 'proc' && (isBrowser || isWebWorker)) {
+    swarm = []
   } else {
     swarm = ['/ip4/127.0.0.1/tcp/0']
   }

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -80,6 +80,8 @@ describe('`createController({test: true})` should return daemon with correct con
 
       if ((isBrowser || isWebWorker) && opts.type !== 'proc') {
         expect(swarm).to.be.deep.eq(['/ip4/127.0.0.1/tcp/0/ws'])
+      } else if ((isBrowser || isWebWorker) && opts.type === 'proc') {
+        expect(swarm).to.be.deep.eq([])
       } else {
         expect(swarm).to.be.deep.eq(['/ip4/127.0.0.1/tcp/0'])
       }


### PR DESCRIPTION
New libp2p is strict about providing addrs that you can listen on.

https://github.com/libp2p/js-libp2p/blob/83409deaa6773a550d38b77bd486faf8b8b97d29/src/transport-manager.js#L172-L176