### PR TITLE
feat: force kill daemons after timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,8 @@ Type: [Object]
     -   `ipfsModule.path` **[string]** Path to a IPFS API implementation to be required. (defaults to the local require.resolve('ipfs'))
 -   `ipfsBin` **[string]** Path to a IPFS exectutable . (defaults to the local 'js-ipfs/src/bin/cli.js')
 -   `ipfsOptions` **[IpfsOptions]** Options for the IPFS instance same as https://github.com/ipfs/js-ipfs#ipfs-constructor. `proc` nodes receive these options as is, daemon nodes translate the options as far as possible to cli arguments.
+- `forceKill` **[boolean]** - Whether to use SIGKILL to quit a daemon that does not stop after `.stop()` is called. (default `true`)
+- `forceKillTimeout` **[Number]** - How long to wait before force killing a daemon in ms. (default `5000`)
 
 
 ## ipfsd-ctl environment variables

--- a/src/factory.js
+++ b/src/factory.js
@@ -30,7 +30,9 @@ const defaults = {
     ref: require('ipfs')
   },
   ipfsBin: findBin('go'),
-  ipfsOptions: {}
+  ipfsOptions: {},
+  forceKill: true,
+  forceKillTimeout: 5000
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,8 @@ module.exports = {
  * @property {string} [ipfsModule.path] - Path to a IPFS API implementation to be required. (defaults to the local require.resolve('ipfs'))
  * @property {String} [ipfsBin] - Path to a IPFS exectutable . (defaults to the local 'js-ipfs/src/bin/cli.js')
  * @property {IpfsOptions} [ipfsOptions] - Options for the IPFS node.
+ * @property {boolean} [forceKill] - Whether to use SIGKILL to quit a daemon that does not stop after `.stop()` is called. (default true)
+ * @property {Number} [forceKillTimeout] - How long to wait before force killing a daemon in ms. (default 5000)
  */
 
 /**

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -243,6 +243,7 @@ class Daemon {
     let killed = false
     if (this.opts.forceKill !== false) {
       killTimeout = setTimeout(() => {
+        // eslint-disable-next-line no-console
         console.error(new Error(`Timeout stopping ${this.opts.type} node. Process ${this.subprocess.pid} will be force killed now.`))
         killed = true
         this.subprocess.kill('SIGKILL')

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -247,11 +247,6 @@ class Daemon {
         console.error(new Error(`Timeout stopping ${this.opts.type} node. Process ${this.subprocess.pid} will be force killed now.`))
         killed = true
 
-        if (this.opts.type === 'go') {
-          // will make go-IPFS print a stack trace to stderr
-          this.subprocess.kill('SIGQUIT')
-        }
-
         this.subprocess.kill('SIGKILL')
       }, this.opts.forceKillTimeout)
     }
@@ -261,7 +256,7 @@ class Daemon {
     } catch (err) {
       if (!killed) throw err // if was killed then ignore error
 
-      daemonLog.info('Daemon was killed')
+      daemonLog.info('Daemon was force killed')
     }
 
     clearTimeout(killTimeout)

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -246,14 +246,22 @@ class Daemon {
         // eslint-disable-next-line no-console
         console.error(new Error(`Timeout stopping ${this.opts.type} node. Process ${this.subprocess.pid} will be force killed now.`))
         killed = true
+
+        if (this.opts.type === 'go') {
+          // will make go-IPFS print a stack trace to stderr
+          this.subprocess.kill('SIGQUIT')
+        }
+
         this.subprocess.kill('SIGKILL')
-      }, this.opts.forceKillTimeout || 10000)
+      }, this.opts.forceKillTimeout)
     }
 
     try {
       await this.api.stop()
     } catch (err) {
       if (!killed) throw err // if was killed then ignore error
+
+      daemonLog.info('Daemon was killed')
     }
 
     clearTimeout(killTimeout)

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -239,7 +239,16 @@ class Daemon {
       return this
     }
 
+    let killTimeout
+    if (this.opts.forceKill !== false) {
+      killTimeout = setTimeout(() => {
+        console.error(new Error(`Timeout stopping ${this.opts.type} node. Process ${this.subprocess.pid} will be force killed now.`))
+        this.subprocess.kill('SIGKILL')
+      }, this.opts.forceKillTimeout || 10000)
+    }
+
     await this.api.stop()
+    clearTimeout(killTimeout)
     this.subprocess.stderr.removeAllListeners()
     this.subprocess.stdout.removeAllListeners()
     this.started = false

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -240,14 +240,21 @@ class Daemon {
     }
 
     let killTimeout
+    let killed = false
     if (this.opts.forceKill !== false) {
       killTimeout = setTimeout(() => {
         console.error(new Error(`Timeout stopping ${this.opts.type} node. Process ${this.subprocess.pid} will be force killed now.`))
+        killed = true
         this.subprocess.kill('SIGKILL')
       }, this.opts.forceKillTimeout || 10000)
     }
 
-    await this.api.stop()
+    try {
+      await this.api.stop()
+    } catch (err) {
+      if (!killed) throw err // if was killed then ignore error
+    }
+
     clearTimeout(killTimeout)
     this.subprocess.stderr.removeAllListeners()
     this.subprocess.stdout.removeAllListeners()


### PR DESCRIPTION
This PR re-adds a feature that was removed in 1.0.0 whereby daemons are force killed with a SIGKILL when they do not stop within a timeout.

It adds 2 new options to the `Daemon` class - `forceKill` (boolean - default `true`) and `forceKillTimeout` (number - default 10000).

resolves https://github.com/ipfs/js-ipfsd-ctl/issues/438