### PR TITLE
chore: update deps

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -4,7 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
-  bundlesize: { maxSize: '928kB' },
+  bundlesize: { maxSize: '930kB' },
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/package.json
+++ b/package.json
@@ -59,11 +59,11 @@
     "go-ipfs-dep": "~0.4.22",
     "ipfs": "0.40.0",
     "ipfs-http-client": "^41.0.0",
-    "ipfs-utils": "^0.6.0",
+    "ipfs-utils": "^0.7.1",
     "ky": "^0.16.1",
     "ky-universal": "^0.3.0",
     "merge-options": "^2.0.0",
-    "multiaddr": "^6.1.1",
+    "multiaddr": "^7.2.1",
     "nanoid": "^2.1.9",
     "resolve-cwd": "^3.0.0",
     "temp-write": "^4.0.0"
@@ -75,7 +75,7 @@
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
     "husky": "^4.0.10",
-    "lint-staged": "^9.5.0"
+    "lint-staged": "^10.0.2"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Otherwise we get multiple versions of multiaddr in the dep tree.

Does not upgrade Hapi because it's dropped support for node 10.  I don't know if we want that decision to be dependency led.