### PR TITLE
feat: move ipfs to peer deps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,11 @@ os:
   - osx
   - windows
 
-script: npx nyc -s npm run test:node -- --timeout 60000
+script:
+  - npm install ipfs
+  - npm install ipfs-http-client
+  - npm install go-ipfs-dep
+  - npx nyc -s npm run test:node -- --timeout 60000
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
 jobs:
@@ -31,6 +35,9 @@ jobs:
       addons:
         chrome: stable
       script:
+        - npm install ipfs
+        - npm install ipfs-http-client
+        - npm install go-ipfs-dep
         - npx aegir test -t browser -t webworker --bail --timeout 60000
 
     - stage: test
@@ -38,18 +45,27 @@ jobs:
       addons:
         firefox: latest
       script:
+        - npm install ipfs
+        - npm install ipfs-http-client
+        - npm install go-ipfs-dep
         - npx aegir test -t browser -t webworker --bail --timeout 60000 -- --browsers FirefoxHeadless
 
     - stage: test
       name: electron-main
       os: osx
       script:
+        - npm install ipfs
+        - npm install ipfs-http-client
+        - npm install go-ipfs-dep
         - npx aegir test -t electron-main --bail --timeout 60000
 
     - stage: test
       name: electron-renderer
       os: osx
       script:
+        - npm install ipfs
+        - npm install ipfs-http-client
+        - npm install go-ipfs-dep
         - npx aegir test -t electron-renderer --bail --timeout 60000
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ jobs:
   include:
     - stage: check
       script:
+        - npm install ipfs
+        - npm install ipfs-http-client
+        - npm install go-ipfs-dep
         - npx aegir build --bundlesize
         - npx aegir commitlint --travis
         - npx aegir dep-check

--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ Version 1.0.0 changed a bit the api and the options methods take so please read 
 npm install --save ipfsd-ctl
 ```
 
+Please ensure your project also has dependencies on `ipfs`, `ipfs-http-client` and `go-ipfs-dep`.
+
+```sh
+npm install --save ipfs
+npm install --save ipfs-http-client
+npm install --save go-ipfs-dep
+```
+
+If you are only going to use the `go` implementation of IPFS, you can skip installing the `js` implementation and vice versa, though both will require the `ipfs-http-client` module.
+
+If you are only using the `proc` type in-process IPFS node, you can skip installing `go-ipfs-dep` and `ipfs-http-client`.
+
 ## Usage
 
 ### Spawning a single IPFS controller: `createController`

--- a/package.json
+++ b/package.json
@@ -56,9 +56,6 @@
     "debug": "^4.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^8.1.0",
-    "go-ipfs-dep": "~0.4.22",
-    "ipfs": "0.40.0",
-    "ipfs-http-client": "^41.0.0",
     "ipfs-utils": "^0.7.1",
     "ky": "^0.16.1",
     "ky-universal": "^0.3.0",
@@ -76,6 +73,11 @@
     "dirty-chai": "^2.0.1",
     "husky": "^4.0.10",
     "lint-staged": "^10.0.2"
+  },
+  "peerDependencies": {
+    "go-ipfs-dep": "*",
+    "ipfs": "*",
+    "ipfs-http-client": "*"
   },
   "repository": {
     "type": "git",

--- a/src/factory.js
+++ b/src/factory.js
@@ -41,14 +41,6 @@ class Factory {
     /** @type ControllerOptions */
     this.opts = merge(defaults, options)
 
-    // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
-    if ((this.opts.type === 'js' || this.opts.type === 'proc') && !this.opts.ipfsModule) {
-      this.opts.ipfsModule = {
-        path: require.resolve('ipfs'),
-        ref: require('ipfs')
-      }
-    }
-
     /** @type ControllerOptionsOverrides */
     this.overrides = merge({
       js: merge(this.opts, { type: 'js', ipfsBin: findBin('js', this.opts.type === 'js') }),
@@ -107,6 +99,14 @@ class Factory {
       this.overrides[options.type || this.opts.type],
       options
     )
+
+    // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
+    if ((opts.type === 'js' || opts.type === 'proc') && !opts.ipfsModule) {
+      opts.ipfsModule = {
+        path: require.resolve('ipfs'),
+        ref: require('ipfs')
+      }
+    }
 
     // IPFS options defaults
     const ipfsOptions = merge(

--- a/src/factory.js
+++ b/src/factory.js
@@ -41,8 +41,8 @@ class Factory {
     /** @type ControllerOptions */
     this.opts = merge(defaults, options)
 
-    // conditionally include ipfs based on which type of daemon we will spawn
-    if (this.opts.type === 'js' || this.opts.type === 'proc') {
+    // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
+    if ((this.opts.type === 'js' || this.opts.type === 'proc') && !this.opts.ipfsModule) {
       this.opts.ipfsModule = {
         path: require.resolve('ipfs'),
         ref: require('ipfs')

--- a/src/factory.js
+++ b/src/factory.js
@@ -25,11 +25,6 @@ const defaults = {
     path: require.resolve('ipfs-http-client'),
     ref: require('ipfs-http-client')
   },
-  ipfsModule: {
-    path: require.resolve('ipfs'),
-    ref: require('ipfs')
-  },
-  ipfsBin: findBin('go'),
   ipfsOptions: {}
 }
 
@@ -46,11 +41,19 @@ class Factory {
     /** @type ControllerOptions */
     this.opts = merge(defaults, options)
 
+    // conditionally include ipfs based on which type of daemon we will spawn
+    if (this.opts.type === 'js' || this.opts.type === 'proc') {
+      this.opts.ipfsModule = {
+        path: require.resolve('ipfs'),
+        ref: require('ipfs')
+      }
+    }
+
     /** @type ControllerOptionsOverrides */
     this.overrides = merge({
-      js: merge(this.opts, { type: 'js', ipfsBin: findBin('js') }),
-      go: this.opts,
-      proc: merge(this.opts, { type: 'proc', ipfsBin: findBin('js') })
+      js: merge(this.opts, { type: 'js', ipfsBin: findBin('js', this.opts.type === 'js') }),
+      go: merge(this.opts, { type: 'go', ipfsBin: findBin('go', this.opts.type === 'go') }),
+      proc: merge(this.opts, { type: 'proc', ipfsBin: findBin('js', this.opts.type === 'proc') })
     }, overrides)
 
     /** @type ControllerDaemon[] */

--- a/src/utils.js
+++ b/src/utils.js
@@ -46,7 +46,7 @@ const findBin = (type) => {
     return process.env.IPFS_JS_EXEC || resolveCwd('ipfs/src/cli/bin.js')
   }
 
-  return process.env.IPFS_GO_EXEC || resolveCwd(`go-ipfs-dep/go-ipfs/${isWindows ? 'ipfs.exe' : 'ipfs'}`)
+  return process.env.IPFS_GO_EXEC || resolveCwd.silent(`go-ipfs-dep/go-ipfs/${isWindows ? 'ipfs.exe' : 'ipfs'}`)
 }
 
 const tmpDir = (type = '') => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -41,12 +41,14 @@ const checkForRunningApi = (repoPath) => {
   return api ? api.toString() : null
 }
 
-const findBin = (type) => {
+const findBin = (type, required) => {
+  const resolve = required ? resolveCwd : resolveCwd.silent
+
   if (type === 'js') {
-    return process.env.IPFS_JS_EXEC || resolveCwd('ipfs/src/cli/bin.js')
+    return process.env.IPFS_JS_EXEC || resolve('ipfs/src/cli/bin.js')
   }
 
-  return process.env.IPFS_GO_EXEC || resolveCwd.silent(`go-ipfs-dep/go-ipfs/${isWindows ? 'ipfs.exe' : 'ipfs'}`)
+  return process.env.IPFS_GO_EXEC || resolve(`go-ipfs-dep/go-ipfs/${isWindows ? 'ipfs.exe' : 'ipfs'}`)
 }
 
 const tmpDir = (type = '') => {


### PR DESCRIPTION
Doing this reduced the size of `node_modules` in the js-IPFS module for me by about 300MB and should result in a faster CI run for js-IPFS since it doesn't need to install itself.
    
Does require the user to bring their own version, but they can also skip installing go-IPFS if, for example, they are only going to use js-IPFS.