### PR TITLE
chore: only build master and PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: node_js
 cache: npm
+branches:
+  only:
+  - master
+  - /^release\/.*$/
 stages:
   - check
   - test


### PR DESCRIPTION
Only build master and release branches, PRs are built by travis so you only get one of these on each PR (e.g. the `Travis CI - Branch` one will not get built):

![image](https://user-images.githubusercontent.com/665810/73078408-03fd6a00-3eba-11ea-93a9-dd7f5655738a.png)
