### PR TITLE
fix: only find bin if not overridden

### DIFF
--- a/src/factory.js
+++ b/src/factory.js
@@ -45,10 +45,18 @@ class Factory {
 
     /** @type ControllerOptionsOverrides */
     this.overrides = merge({
-      js: merge(this.opts, { type: 'js', ipfsBin: findBin('js', this.opts.type === 'js') }),
-      go: merge(this.opts, { type: 'go', ipfsBin: findBin('go', this.opts.type === 'go') }),
-      proc: merge(this.opts, { type: 'proc', ipfsBin: findBin('js', this.opts.type === 'proc') })
+      js: merge(this.opts, { type: 'js' }),
+      go: merge(this.opts, { type: 'go' }),
+      proc: merge(this.opts, { type: 'proc' })
     }, overrides)
+
+    if (!this.overrides.js.ipfsBin) {
+      this.overrides.js.ipfsBin = findBin('js', this.opts.type === 'js')
+    }
+
+    if (!this.overrides.go.ipfsBin) {
+      this.overrides.go.ipfsBin = findBin('go', this.opts.type === 'go')
+    }
 
     /** @type ControllerDaemon[] */
     this.controllers = []


### PR DESCRIPTION
Only use `findBin` if it's not been specified in options.

In js-ipfs we set `ipfsBin` to be `./src/cli/bin.js` and there is no `ipfs` module installed (we are the module).

Proc node does not use `ipfsBin`