### PR TITLE
fix: only require http api client if it has not been specified

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -4,7 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
-  bundlesize: { maxSize: '930kB' },
+  bundlesize: { maxSize: '940kB' },
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/.aegir.js
+++ b/.aegir.js
@@ -16,5 +16,12 @@ module.exports = {
   hooks: {
       pre: () => server.start(),
       post: () => server.stop()
+  },
+  webpack: {
+    externals: {
+      ipfs: 'ipfs',
+      'ipfs-http-client': 'ipfs-http-client',
+      'go-ipfs-dep': 'go-ifps-dep'
+    }
   }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -17,11 +17,11 @@ module.exports = {
       pre: () => server.start(),
       post: () => server.stop()
   },
-  webpack: {
+  webpack: process.env.NODE_ENV === 'test' ? undefined : {
     externals: {
       ipfs: 'ipfs',
       'ipfs-http-client': 'ipfs-http-client',
-      'go-ipfs-dep': 'go-ifps-dep'
+      'go-ipfs-dep': 'go-ipfs-dep'
     }
   }
 }

--- a/.aegir.js
+++ b/.aegir.js
@@ -4,7 +4,7 @@ const createServer = require('./src').createServer
 
 const server = createServer() // using defaults
 module.exports = {
-  bundlesize: { maxSize: '940kB' },
+  bundlesize: { maxSize: '35kB' },
   karma: {
     files: [{
       pattern: 'test/fixtures/**/*',

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,6 @@ os:
   - windows
 
 script:
-  - npm install ipfs
-  - npm install ipfs-http-client
-  - npm install go-ipfs-dep
   - npx nyc -s npm run test:node -- --timeout 60000
 after_success: npx nyc report --reporter=text-lcov > coverage.lcov && npx codecov
 
@@ -29,9 +26,6 @@ jobs:
   include:
     - stage: check
       script:
-        - npm install ipfs
-        - npm install ipfs-http-client
-        - npm install go-ipfs-dep
         - npx aegir build --bundlesize
         - npx aegir commitlint --travis
         - npx aegir dep-check
@@ -42,10 +36,6 @@ jobs:
       addons:
         chrome: stable
       script:
-        - npm install ipfs
-        - npm install ipfs-http-client
-        - npm install go-ipfs-dep
-        - npm run build
         - npx aegir test -t browser -t webworker --bail --timeout 60000
 
     - stage: test
@@ -53,28 +43,18 @@ jobs:
       addons:
         firefox: latest
       script:
-        - npm install ipfs
-        - npm install ipfs-http-client
-        - npm install go-ipfs-dep
-        - npm run build
         - npx aegir test -t browser -t webworker --bail --timeout 60000 -- --browsers FirefoxHeadless
 
     - stage: test
       name: electron-main
       os: osx
       script:
-        - npm install ipfs
-        - npm install ipfs-http-client
-        - npm install go-ipfs-dep
         - npx aegir test -t electron-main --bail --timeout 60000
 
     - stage: test
       name: electron-renderer
       os: osx
       script:
-        - npm install ipfs
-        - npm install ipfs-http-client
-        - npm install go-ipfs-dep
         - npx aegir test -t electron-renderer --bail --timeout 60000
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ jobs:
         - npm install ipfs
         - npm install ipfs-http-client
         - npm install go-ipfs-dep
+        - npm run build
         - npx aegir test -t browser -t webworker --bail --timeout 60000
 
     - stage: test
@@ -55,6 +56,7 @@ jobs:
         - npm install ipfs
         - npm install ipfs-http-client
         - npm install go-ipfs-dep
+        - npm run build
         - npx aegir test -t browser -t webworker --bail --timeout 60000 -- --browsers FirefoxHeadless
 
     - stage: test

--- a/package.json
+++ b/package.json
@@ -71,7 +71,10 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
+    "go-ipfs-dep": "^0.4.22",
     "husky": "^4.0.10",
+    "ipfs": "github:ipfs/js-ipfs#master",
+    "ipfs-http-client": "^42.0.0-pre.0",
     "lint-staged": "^10.0.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "dirty-chai": "^2.0.1",
     "go-ipfs-dep": "^0.4.22",
     "husky": "^4.0.10",
-    "ipfs": "github:ipfs/js-ipfs#master",
+    "ipfs": "^0.40.0",
     "ipfs-http-client": "^42.0.0-pre.0",
     "lint-staged": "^10.0.2"
   },

--- a/src/factory.js
+++ b/src/factory.js
@@ -21,6 +21,7 @@ const defaults = {
   type: 'go',
   env: {},
   args: [],
+  ipfsModule: {},
   ipfsOptions: {},
   forceKill: true,
   forceKillTimeout: 5000

--- a/src/factory.js
+++ b/src/factory.js
@@ -21,7 +21,6 @@ const defaults = {
   type: 'go',
   env: {},
   args: [],
-  ipfsModule: {},
   ipfsOptions: {},
   forceKill: true,
   forceKillTimeout: 5000

--- a/src/factory.js
+++ b/src/factory.js
@@ -77,30 +77,24 @@ class Factory {
     const opts = {
       json: {
         ...options,
+        ipfsModule: undefined,
+        ipfsHttpModule: undefined,
         // avoid recursive spawning
         remote: false
       }
     }
 
-    if (options.ipfsModule) {
-      delete opts.ipfsModule
-
-      if (options.ipfsModule.path) {
-        opts.ipfsModule = {
-          path: options.ipfsModule.path
-          // n.b. no ref property - do not send code refs over http
-        }
+    if (options.ipfsModule && options.ipfsModule.path) {
+      opts.json.ipfsModule = {
+        path: options.ipfsModule.path
+        // n.b. no ref property - do not send code refs over http
       }
     }
 
-    if (options.ipfsHttpModule) {
-      delete opts.ipfsHttpModule
-
-      if (options.ipfsHttpModule.path) {
-        opts.ipfsHttpModule = {
-          path: options.ipfsHttpModule.path
-          // n.b. no ref property - do not send code refs over http
-        }
+    if (options.ipfsHttpModule && options.ipfsHttpModule.path) {
+      opts.json.ipfsHttpModule = {
+        path: options.ipfsHttpModule.path
+        // n.b. no ref property - do not send code refs over http
       }
     }
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -47,14 +47,6 @@ class Factory {
       proc: merge(this.opts, { type: 'proc' })
     }, overrides)
 
-    if (!this.overrides.js.ipfsBin) {
-      this.overrides.js.ipfsBin = findBin('js', this.opts.type === 'js')
-    }
-
-    if (!this.overrides.go.ipfsBin) {
-      this.overrides.go.ipfsBin = findBin('go', this.opts.type === 'go')
-    }
-
     /** @type ControllerDaemon[] */
     this.controllers = []
   }
@@ -138,6 +130,16 @@ class Factory {
         path: require.resolve('ipfs-http-client'),
         ref: require('ipfs-http-client')
       }
+    }
+
+    // find ipfs binary if not specified
+    if (!opts.ipfsBin && opts.type === 'js') {
+      opts.ipfsBin = findBin('js', true)
+    }
+
+    // find ipfs binary if not specified
+    if (!opts.ipfsBin && opts.type === 'go') {
+      opts.ipfsBin = findBin('go', true)
     }
 
     // IPFS options defaults

--- a/src/factory.js
+++ b/src/factory.js
@@ -103,7 +103,6 @@ class Factory {
   async spawn (options = { }) {
     const type = options.type || this.opts.type
     const opts = merge(
-      this.opts,
       this.overrides[type],
       options
     )

--- a/src/factory.js
+++ b/src/factory.js
@@ -133,13 +133,8 @@ class Factory {
     }
 
     // find ipfs binary if not specified
-    if (!opts.ipfsBin && opts.type === 'js') {
-      opts.ipfsBin = findBin('js', true)
-    }
-
-    // find ipfs binary if not specified
-    if (!opts.ipfsBin && opts.type === 'go') {
-      opts.ipfsBin = findBin('go', true)
+    if (opts.type !== 'proc' && !opts.ipfsBin) {
+      opts.ipfsBin = findBin(opts.type, true)
     }
 
     // IPFS options defaults

--- a/src/factory.js
+++ b/src/factory.js
@@ -115,7 +115,7 @@ class Factory {
       options
     )
 
-    // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
+    // conditionally include ipfs based on which type of daemon we will spawn when none has been specified
     if ((opts.type === 'js' || opts.type === 'proc') && !opts.ipfsModule) {
       opts.ipfsModule = {}
     }

--- a/src/factory.js
+++ b/src/factory.js
@@ -103,6 +103,7 @@ class Factory {
   async spawn (options = { }) {
     const type = options.type || this.opts.type
     const opts = merge(
+      this.opts,
       this.overrides[type],
       options
     )

--- a/src/factory.js
+++ b/src/factory.js
@@ -21,11 +21,6 @@ const defaults = {
   type: 'go',
   env: {},
   args: [],
-  ipfsHttpModule: {
-    path: require.resolve('ipfs-http-client'),
-    ref: require('ipfs-http-client')
-  },
-  ipfsModule: {},
   ipfsOptions: {},
   forceKill: true,
   forceKillTimeout: 5000
@@ -125,6 +120,16 @@ class Factory {
       } : {},
       options
     )
+
+    // only include the http api client if it has not been specified as an option
+    // for example if we are testing the http api client itself we should not try
+    // to require 'ipfs-http-client'
+    if (!opts.ipfsHttpModule) {
+      opts.ipfsHttpModule = {
+        path: require.resolve('ipfs-http-client'),
+        ref: require('ipfs-http-client')
+      }
+    }
 
     // IPFS options defaults
     const ipfsOptions = merge(

--- a/src/factory.js
+++ b/src/factory.js
@@ -74,18 +74,39 @@ class Factory {
   }
 
   async _spawnRemote (options) {
-    const res = await ky.post(
-      `${options.endpoint}/spawn`,
-      {
-        json: {
-          ...options,
-          // avoid recursive spawning
-          remote: false,
-          // do not send code refs over http
-          ipfsModule: { ...options.ipfsModule, ref: undefined },
-          ipfsHttpModule: { ...options.ipfsHttpModule, ref: undefined }
+    const opts = {
+      json: {
+        ...options,
+        // avoid recursive spawning
+        remote: false
+      }
+    }
+
+    if (options.ipfsModule) {
+      delete opts.ipfsModule
+
+      if (options.ipfsModule.path) {
+        opts.ipfsModule = {
+          path: options.ipfsModule.path
+          // n.b. no ref property - do not send code refs over http
         }
       }
+    }
+
+    if (options.ipfsHttpModule) {
+      delete opts.ipfsHttpModule
+
+      if (options.ipfsHttpModule.path) {
+        opts.ipfsHttpModule = {
+          path: options.ipfsHttpModule.path
+          // n.b. no ref property - do not send code refs over http
+        }
+      }
+    }
+
+    const res = await ky.post(
+      `${options.endpoint}/spawn`,
+      opts
     ).json()
     return new ControllerRemote(
       options.endpoint,

--- a/src/factory.js
+++ b/src/factory.js
@@ -126,7 +126,7 @@ class Factory {
       }
 
       if (!opts.ipfsModule.ref) {
-        opts.ipfsModule.ref = require(opts.ipfsModule.path)
+        opts.ipfsModule.ref = require('ipfs')
       }
     }
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -112,15 +112,23 @@ class Factory {
     const type = options.type || this.opts.type
     const opts = merge(
       this.overrides[type],
-      // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
-      (type === 'js' || type === 'proc') ? {
-        ipfsModule: {
-          path: require.resolve('ipfs'),
-          ref: require('ipfs')
-        }
-      } : {},
       options
     )
+
+    // conditionally include ipfs based on which type of daemon we will spawn when none has been specifed
+    if ((opts.type === 'js' || opts.type === 'proc') && !opts.ipfsModule) {
+      opts.ipfsModule = {}
+    }
+
+    if (opts.ipfsModule) {
+      if (!opts.ipfsModule.path) {
+        opts.ipfsModule.path = require.resolve('ipfs')
+      }
+
+      if (!opts.ipfsModule.ref) {
+        opts.ipfsModule.ref = require(opts.ipfsModule.path)
+      }
+    }
 
     // only include the http api client if it has not been specified as an option
     // for example if we are testing the http api client itself we should not try


### PR DESCRIPTION
If we configure which http api module to use, don't try to require `ipfs-http-client`, because that then means the containing project needs to specify a dependency on `ipfs-http-client` when the containing project might actually be `ipfs-http-client`...