### PR TITLE
refactor: remove option normalisation

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,8 +1,25 @@
 'use strict'
 
 const createServer = require('./src').createServer
+const { findBin } = require('./src/utils')
 
-const server = createServer() // using defaults
+const server = createServer(null, {
+  ipfsModule: {
+    path: require.resolve('ipfs'),
+    ref: require('ipfs')
+  },
+  ipfsHttpModule: {
+    path: require.resolve('ipfs-http-client'),
+    ref: require('ipfs-http-client')
+  }
+}, {
+  go: {
+    ipfsBin: findBin('go', true)
+  },
+  js: {
+    ipfsBin: findBin('js', true)
+  }
+}) // using defaults
 module.exports = {
   bundlesize: { maxSize: '35kB' },
   karma: {

--- a/src/endpoint/routes.js
+++ b/src/endpoint/routes.js
@@ -20,7 +20,7 @@ const badRequest = err => {
   } else {
     msg = err.message
   }
-  debug(msg)
+  debug(err)
   throw boom.badRequest(msg)
 }
 

--- a/src/factory.js
+++ b/src/factory.js
@@ -77,24 +77,8 @@ class Factory {
     const opts = {
       json: {
         ...options,
-        ipfsModule: undefined,
-        ipfsHttpModule: undefined,
         // avoid recursive spawning
         remote: false
-      }
-    }
-
-    if (options.ipfsModule && options.ipfsModule.path) {
-      opts.json.ipfsModule = {
-        path: options.ipfsModule.path
-        // n.b. no ref property - do not send code refs over http
-      }
-    }
-
-    if (options.ipfsHttpModule && options.ipfsHttpModule.path) {
-      opts.json.ipfsHttpModule = {
-        path: options.ipfsHttpModule.path
-        // n.b. no ref property - do not send code refs over http
       }
     }
 
@@ -120,36 +104,6 @@ class Factory {
       this.overrides[type],
       options
     )
-
-    // conditionally include ipfs based on which type of daemon we will spawn when none has been specified
-    if ((opts.type === 'js' || opts.type === 'proc') && !opts.ipfsModule) {
-      opts.ipfsModule = {}
-    }
-
-    if (opts.ipfsModule) {
-      if (!opts.ipfsModule.path) {
-        opts.ipfsModule.path = require.resolve('ipfs')
-      }
-
-      if (!opts.ipfsModule.ref) {
-        opts.ipfsModule.ref = require('ipfs')
-      }
-    }
-
-    // only include the http api client if it has not been specified as an option
-    // for example if we are testing the http api client itself we should not try
-    // to require 'ipfs-http-client'
-    if (!opts.ipfsHttpModule) {
-      opts.ipfsHttpModule = {
-        path: require.resolve('ipfs-http-client'),
-        ref: require('ipfs-http-client')
-      }
-    }
-
-    // find ipfs binary if not specified
-    if (opts.type !== 'proc' && !opts.ipfsBin) {
-      opts.ipfsBin = findBin(opts.type, true)
-    }
 
     // IPFS options defaults
     const ipfsOptions = merge(

--- a/src/factory.js
+++ b/src/factory.js
@@ -1,7 +1,7 @@
 'use strict'
 const merge = require('merge-options').bind({ ignoreUndefined: true })
 const kyOriginal = require('ky-universal').default
-const { tmpDir, findBin } = require('./utils')
+const { tmpDir } = require('./utils')
 const { isNode } = require('ipfs-utils/src/env')
 const ControllerDaemon = require('./ipfsd-daemon')
 const ControllerRemote = require('./ipfsd-client')

--- a/src/index.js
+++ b/src/index.js
@@ -32,13 +32,18 @@ const createController = (options) => {
  *
  * @param {(Object|number)} options - Configuration options or just the port.
  * @param {number} options.port - Port to start the server on.
+ * @param {ControllerOptions} factoryOptions
+ * @param {ControllerOptionsOverrides} factoryOverrides
  * @returns {Server}
  */
-const createServer = (options) => {
+const createServer = (options, factoryOptions = {}, factoryOverrides = {}) => {
   if (typeof options === 'number') {
     options = { port: options }
   }
-  return new Server(options, createFactory)
+
+  return new Server(options, () => {
+    return createFactory(factoryOptions, factoryOverrides)
+  })
 }
 
 module.exports = {

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -34,8 +34,9 @@ class Client {
     this.disposable = remoteState.disposable
     this.clean = remoteState.clean
     this.api = null
-    this.apiAddr = this._setApi(remoteState.apiAddr)
-    this.gatewayAddr = this._setGateway(remoteState.gatewayAddr)
+
+    this._setApi(remoteState.apiAddr)
+    this._setGateway(remoteState.gatewayAddr)
   }
 
   /**

--- a/test/browser.utils.js
+++ b/test/browser.utils.js
@@ -36,7 +36,11 @@ describe('utils browser version', function () {
         test: true,
         type: 'proc',
         disposable: false,
-        ipfsOptions: { repo: 'ipfs_test_remove' }
+        ipfsOptions: { repo: 'ipfs_test_remove' },
+        ipfsModule: {
+          path: require.resolve('ipfs'),
+          ref: require('ipfs')
+        }
       })
       await ctl.init()
       await ctl.start()
@@ -51,7 +55,16 @@ describe('utils browser version', function () {
     describe('repoExists', () => {
       it('should resolve true when repo exists', async () => {
         const f = createFactory({ test: true })
-        const node = await f.spawn({ type: 'proc', ipfsOptions: { repo: 'ipfs_test' } })
+        const node = await f.spawn({
+          type: 'proc',
+          ipfsOptions: {
+            repo: 'ipfs_test'
+          },
+          ipfsModule: {
+            path: require.resolve('ipfs'),
+            ref: require('ipfs')
+          }
+        })
         expect(await repoExists('ipfs_test')).to.be.true()
         await node.stop()
       })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -13,16 +13,77 @@ const expect = chai.expect
 chai.use(dirtyChai)
 chai.use(chaiPromise)
 
-const types = [
-  { type: 'js', test: true, ipfsOptions: { init: false, start: false } },
-  { type: 'go', test: true, ipfsOptions: { init: false, start: false } },
-  { type: 'proc', test: true, ipfsOptions: { init: false, start: false } },
-  { type: 'js', remote: true, test: true, ipfsOptions: { init: false, start: false } },
-  { type: 'go', remote: true, test: true, ipfsOptions: { init: false, start: false } }
-]
+const defaultOpts = {
+  ipfsModule: {
+    path: require.resolve('ipfs'),
+    ref: require('ipfs')
+  },
+  ipfsHttpModule: {
+    path: require.resolve('ipfs-http-client'),
+    ref: require('ipfs-http-client')
+  },
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js'),
+}
+
+const types = [{
+  ...defaultOpts,
+  type: 'js',
+  test: true,
+  ipfsOptions: {
+    init: false,
+    start: false
+  }
+}, {
+  ...defaultOpts,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  test: true,
+  ipfsOptions: {
+    init: false,
+    start: false
+  }
+}, {
+  ...defaultOpts,
+  type: 'proc',
+  test: true,
+  ipfsOptions: {
+    init: false,
+    start: false
+  }
+}, {
+  ...defaultOpts,
+  type: 'js',
+  remote: true,
+  test: true,
+  ipfsOptions: {
+    init: false,
+    start: false
+  }
+}, {
+  ...defaultOpts,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  remote: true,
+  test: true,
+  ipfsOptions: {
+    init: false,
+    start: false
+  }
+}]
 
 describe('Controller API', () => {
-  const factory = createFactory({ test: true })
+  const factory = createFactory({
+    test: true,
+    ipfsModule: {
+      path: require.resolve('ipfs'),
+      ref: require('ipfs')
+    },
+    ipfsHttpModule: {
+      path: require.resolve('ipfs-http-client'),
+      ref: require('ipfs-http-client')
+    },
+    ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+  })
 
   before(() => factory.spawn({ type: 'js' }))
 
@@ -48,7 +109,11 @@ describe('Controller API', () => {
     describe('should work with a initialized repo', () => {
       for (const opts of types) {
         it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
-          const ctl = await createController(merge(opts, { ipfsOptions: { repo: factory.controllers[0].path } }))
+          const ctl = await createController(merge(opts, {
+            ipfsOptions: {
+              repo: factory.controllers[0].path
+            }
+          }))
 
           await ctl.init()
           expect(ctl.initialized).to.be.true()
@@ -130,8 +195,11 @@ describe('Controller API', () => {
             return this.skip() // browser in proc can't attach to running node
           }
           const ctl = await createController(merge(
-            opts,
-            { ipfsOptions: { repo: factory.controllers[0].path } }
+            opts, {
+              ipfsOptions: {
+                repo: factory.controllers[0].path
+              }
+            }
           ))
 
           await ctl.init()
@@ -184,10 +252,7 @@ describe('Controller API', () => {
           const f = createFactory()
           const ctl = await f.spawn(merge(opts, {
             disposable: false,
-            test: true,
-            ipfsOptions: {
-              repo: await f.tmpDir()
-            }
+            test: true
           }))
 
           await ctl.init()

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -22,7 +22,7 @@ const defaultOpts = {
     path: require.resolve('ipfs-http-client'),
     ref: require('ipfs-http-client')
   },
-  ipfsBin: require.resolve('ipfs/src/cli/bin.js'),
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }
 
 const types = [{

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -6,9 +6,8 @@ const merge = require('merge-options')
 const dirtyChai = require('dirty-chai')
 const chaiPromise = require('chai-as-promised')
 const { createFactory, createController } = require('../src')
-const { repoExists } = require('../src/utils')
+const { repoExists, findBin } = require('../src/utils')
 const { isBrowser, isWebWorker } = require('ipfs-utils/src/env')
-const os = require('os')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -23,7 +22,7 @@ const defaultOpts = {
     path: require.resolve('ipfs-http-client'),
     ref: require('ipfs-http-client')
   },
-  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+  ipfsBin: findBin('js', true)
 }
 
 const types = [{
@@ -36,7 +35,7 @@ const types = [{
   }
 }, {
   ...defaultOpts,
-  ipfsBin: require.resolve(`go-ipfs-dep/go-ipfs/ipfs${os.platform() === 'win32' ? '.exe' : ''}`),
+  ipfsBin: findBin('go', true),
   type: 'go',
   test: true,
   ipfsOptions: {
@@ -62,7 +61,7 @@ const types = [{
   }
 }, {
   ...defaultOpts,
-  ipfsBin: require.resolve(`go-ipfs-dep/go-ipfs/ipfs${os.platform() === 'win32' ? '.exe' : ''}`),
+  ipfsBin: findBin('go', true),
   type: 'go',
   remote: true,
   test: true,
@@ -72,7 +71,7 @@ const types = [{
   }
 }]
 
-describe('Controller API', () => {
+describe.only('Controller API', () => {
   const factory = createFactory({
     test: true,
     ipfsModule: {
@@ -83,7 +82,7 @@ describe('Controller API', () => {
       path: require.resolve('ipfs-http-client'),
       ref: require('ipfs-http-client')
     },
-    ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+    ipfsBin: findBin('js', true)
   })
 
   before(() => factory.spawn({ type: 'js' }))

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -8,6 +8,7 @@ const chaiPromise = require('chai-as-promised')
 const { createFactory, createController } = require('../src')
 const { repoExists } = require('../src/utils')
 const { isBrowser, isWebWorker } = require('ipfs-utils/src/env')
+const os = require('os')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -35,7 +36,7 @@ const types = [{
   }
 }, {
   ...defaultOpts,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: require.resolve(`go-ipfs-dep/go-ipfs/ipfs${os.platform() === 'win32' ? '.exe' : ''}`),
   type: 'go',
   test: true,
   ipfsOptions: {
@@ -61,7 +62,7 @@ const types = [{
   }
 }, {
   ...defaultOpts,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: require.resolve(`go-ipfs-dep/go-ipfs/ipfs${os.platform() === 'win32' ? '.exe' : ''}`),
   type: 'go',
   remote: true,
   test: true,

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -71,7 +71,7 @@ const types = [{
   }
 }]
 
-describe.only('Controller API', () => {
+describe('Controller API', () => {
   const factory = createFactory({
     test: true,
     ipfsModule: {

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -26,7 +26,7 @@ describe('`createController` should return the correct class', () => {
         ref: require('ipfs-http-client')
       },
       ipfsBin: require.resolve('ipfs/src/cli/bin.js')
-     })
+    })
 
     if (!isNode) {
       expect(f).to.be.instanceOf(Client)

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -8,6 +8,7 @@ const { createFactory, createController, createServer } = require('../src')
 const Client = require('../src/ipfsd-client')
 const Daemon = require('../src/ipfsd-daemon')
 const Proc = require('../src/ipfsd-in-proc')
+const { findBin } = require('../src/utils')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -25,7 +26,7 @@ describe('`createController` should return the correct class', () => {
         path: require.resolve('ipfs-http-client'),
         ref: require('ipfs-http-client')
       },
-      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+      ipfsBin: findBin('js', true)
     })
 
     if (!isNode) {
@@ -42,7 +43,7 @@ describe('`createController` should return the correct class', () => {
         path: require.resolve('ipfs-http-client'),
         ref: require('ipfs-http-client')
       },
-      ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs')
+      ipfsBin: findBin('go', true)
     })
 
     if (!isNode) {
@@ -69,7 +70,7 @@ describe('`createController` should return the correct class', () => {
         path: require.resolve('ipfs-http-client'),
         ref: require('ipfs-http-client')
       },
-      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+      ipfsBin: findBin('js', true)
     })
 
     expect(f).to.be.instanceOf(Client)
@@ -85,7 +86,7 @@ const defaultOps = {
     path: require.resolve('ipfs-http-client'),
     ref: require('ipfs-http-client')
   },
-  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+  ipfsBin: findBin('js', true)
 }
 
 const types = [{
@@ -94,7 +95,7 @@ const types = [{
   test: true
 }, {
   ...defaultOps,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: findBin('go', true),
   type: 'go',
   test: true
 }, {
@@ -108,7 +109,7 @@ const types = [{
   remote: true
 }, {
   ...defaultOps,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: findBin('go', true),
   type: 'go',
   test: true,
   remote: true

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -14,7 +14,19 @@ chai.use(dirtyChai)
 
 describe('`createController` should return the correct class', () => {
   it('for type `js` ', async () => {
-    const f = await createController({ type: 'js', disposable: false })
+    const f = await createController({
+      type: 'js',
+      disposable: false,
+      ipfsModule: {
+        path: require.resolve('ipfs'),
+        ref: require('ipfs')
+      },
+      ipfsHttpModule: {
+        path: require.resolve('ipfs-http-client'),
+        ref: require('ipfs-http-client')
+      },
+      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+     })
 
     if (!isNode) {
       expect(f).to.be.instanceOf(Client)
@@ -23,7 +35,15 @@ describe('`createController` should return the correct class', () => {
     }
   })
   it('for type `go` ', async () => {
-    const f = await createController({ type: 'go', disposable: false })
+    const f = await createController({
+      type: 'go',
+      disposable: false,
+      ipfsHttpModule: {
+        path: require.resolve('ipfs-http-client'),
+        ref: require('ipfs-http-client')
+      },
+      ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs')
+    })
 
     if (!isNode) {
       expect(f).to.be.instanceOf(Client)
@@ -38,19 +58,61 @@ describe('`createController` should return the correct class', () => {
   })
 
   it('for remote', async () => {
-    const f = await createController({ remote: true, disposable: false })
+    const f = await createController({
+      remote: true,
+      disposable: false,
+      ipfsModule: {
+        path: require.resolve('ipfs'),
+        ref: require('ipfs')
+      },
+      ipfsHttpModule: {
+        path: require.resolve('ipfs-http-client'),
+        ref: require('ipfs-http-client')
+      },
+      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+    })
 
     expect(f).to.be.instanceOf(Client)
   })
 })
 
-const types = [
-  { type: 'js', test: true },
-  { type: 'go', test: true },
-  { type: 'proc', test: true },
-  { type: 'js', test: true, remote: true },
-  { type: 'go', test: true, remote: true }
-]
+const defaultOps = {
+  ipfsModule: {
+    path: require.resolve('ipfs'),
+    ref: require('ipfs')
+  },
+  ipfsHttpModule: {
+    path: require.resolve('ipfs-http-client'),
+    ref: require('ipfs-http-client')
+  },
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+}
+
+const types = [{
+  ...defaultOps,
+  type: 'js',
+  test: true
+}, {
+  ...defaultOps,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  test: true
+}, {
+  ...defaultOps,
+  type: 'proc',
+  test: true
+}, {
+  ...defaultOps,
+  type: 'js',
+  test: true,
+  remote: true
+}, {
+  ...defaultOps,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  test: true,
+  remote: true
+}]
 
 describe('`createController` should return daemon with peerId when started', () => {
   for (const opts of types) {
@@ -105,7 +167,9 @@ describe('`createController({test: true})` should return daemon with correct con
 describe('`createFactory({test: true})` should return daemon with test profile', () => {
   for (const opts of types) {
     it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
-      const factory = createFactory({ test: true })
+      const factory = createFactory({
+        test: true
+      })
       const node = await factory.spawn(opts)
       expect(await node.api.config.get('Bootstrap')).to.be.empty()
       await factory.clean()

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -25,7 +25,7 @@ const types = [{
   ...defaultOps,
   type: 'js',
   test: true
-},{
+}, {
   ...defaultOps,
   ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
   type: 'go',

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -5,6 +5,7 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const { isNode } = require('ipfs-utils/src/env')
 const { createFactory } = require('../src')
+const { findBin } = require('../src/utils')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -18,7 +19,7 @@ const defaultOps = {
     path: require.resolve('ipfs-http-client'),
     ref: require('ipfs-http-client')
   },
-  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+  ipfsBin: findBin('js', true)
 }
 
 const types = [{
@@ -27,7 +28,7 @@ const types = [{
   test: true
 }, {
   ...defaultOps,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: findBin('go', true),
   type: 'go',
   test: true
 }, {
@@ -41,7 +42,7 @@ const types = [{
   test: true
 }, {
   ...defaultOps,
-  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  ipfsBin: findBin('go', true),
   type: 'go',
   remote: true,
   test: true
@@ -99,7 +100,7 @@ describe('`Factory spawn()` ', () => {
             path: require.resolve('ipfs-http-client'),
             ref: require('ipfs-http-client')
           },
-          ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+          ipfsBin: findBin('js', true)
         })
         expect(ctl).to.exist()
         expect(ctl.opts.test).to.be.true()

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -9,13 +9,43 @@ const { createFactory } = require('../src')
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const types = [
-  { type: 'js', test: true },
-  { type: 'go', test: true },
-  { type: 'proc', test: true },
-  { type: 'js', remote: true, test: true },
-  { type: 'go', remote: true, test: true }
-]
+const defaultOps = {
+  ipfsModule: {
+    path: require.resolve('ipfs'),
+    ref: require('ipfs')
+  },
+  ipfsHttpModule: {
+    path: require.resolve('ipfs-http-client'),
+    ref: require('ipfs-http-client')
+  },
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+}
+
+const types = [{
+  ...defaultOps,
+  type: 'js',
+  test: true
+},{
+  ...defaultOps,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  test: true
+}, {
+  ...defaultOps,
+  type: 'proc',
+  test: true
+}, {
+  ...defaultOps,
+  type: 'js',
+  remote: true,
+  test: true
+}, {
+  ...defaultOps,
+  ipfsBin: require.resolve('go-ipfs-dep/go-ipfs/ipfs'),
+  type: 'go',
+  remote: true,
+  test: true
+}]
 
 describe('`Factory tmpDir()` should return correct temporary dir', () => {
   for (const opts of types) {
@@ -58,7 +88,19 @@ describe('`Factory spawn()` ', () => {
     for (const opts of types) {
       it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
         const factory = await createFactory({ test: true })
-        const ctl = await factory.spawn({ type: opts.type, remote: opts.remote })
+        const ctl = await factory.spawn({
+          type: opts.type,
+          remote: opts.remote,
+          ipfsModule: {
+            path: require.resolve('ipfs'),
+            ref: require('ipfs')
+          },
+          ipfsHttpModule: {
+            path: require.resolve('ipfs-http-client'),
+            ref: require('ipfs-http-client')
+          },
+          ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+        })
         expect(ctl).to.exist()
         expect(ctl.opts.test).to.be.true()
         await ctl.stop()

--- a/test/node.routes.js
+++ b/test/node.routes.js
@@ -16,7 +16,19 @@ describe('routes', () => {
 
   before(() => {
     server = new Hapi.Server({ port: 43134 })
-    routes(server, createFactory)
+    routes(server, () => {
+      return createFactory({
+        ipfsModule: {
+          path: require.resolve('ipfs'),
+          ref: require('ipfs')
+        },
+        ipfsHttpModule: {
+          path: require.resolve('ipfs-http-client'),
+          ref: require('ipfs-http-client')
+        },
+        ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+      })
+    })
   })
 
   after(async () => {

--- a/test/node.utils.js
+++ b/test/node.utils.js
@@ -44,7 +44,18 @@ describe('utils node version', function () {
       expect(checkForRunningApi()).to.be.null()
     })
     it('should return path to api with running node', async () => {
-      const node = await createController({ test: true })
+      const node = await createController({
+        test: true,
+        ipfsModule: {
+          path: require.resolve('ipfs'),
+          ref: require('ipfs')
+        },
+        ipfsHttpModule: {
+          path: require.resolve('ipfs-http-client'),
+          ref: require('ipfs-http-client')
+        },
+        ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+      })
       expect(checkForRunningApi(node.path)).to.be.contain('/ip4/127.0.0.1/tcp/')
       await node.stop()
     })
@@ -57,7 +68,18 @@ describe('utils node version', function () {
   })
 
   it('removeRepo should work', async () => {
-    const f = createFactory({ test: true })
+    const f = createFactory({
+      test: true,
+      ipfsModule: {
+        path: require.resolve('ipfs'),
+        ref: require('ipfs')
+      },
+      ipfsHttpModule: {
+        path: require.resolve('ipfs-http-client'),
+        ref: require('ipfs-http-client')
+      },
+      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+    })
     const dir = await f.tmpDir()
     const node = await f.spawn({
       type: 'proc',
@@ -73,7 +95,19 @@ describe('utils node version', function () {
 
   describe('repoExists', () => {
     it('should resolve true when repo exists', async () => {
-      const node = await createController({ type: 'proc', test: true })
+      const node = await createController({
+        type: 'proc',
+        test: true,
+        ipfsModule: {
+          path: require.resolve('ipfs'),
+          ref: require('ipfs')
+        },
+        ipfsHttpModule: {
+          path: require.resolve('ipfs-http-client'),
+          ref: require('ipfs-http-client')
+        },
+        ipfsBin: require.resolve('ipfs/src/cli/bin.js')
+      })
       expect(await repoExists(node.path)).to.be.true()
       await node.stop()
     })


### PR DESCRIPTION
There are just too many options, too many variables and too many different calling contexts so let's get the user to be explicit about how they intend to use the module rather than try to second guess them.

Also, allow the user to specify opts/overrides to the ipfsd server's use of `createFactory`.