### PR TITLE
refactor: remove path and ref from module args also findBin

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,23 +1,16 @@
 'use strict'
 
 const createServer = require('./src').createServer
-const { findBin } = require('./src/utils')
 
 const server = createServer(null, {
-  ipfsModule: {
-    path: require.resolve('ipfs'),
-    ref: require('ipfs')
-  },
-  ipfsHttpModule: {
-    path: require.resolve('ipfs-http-client'),
-    ref: require('ipfs-http-client')
-  }
+  ipfsModule: require('ipfs'),
+  ipfsHttpModule: require('ipfs-http-client')
 }, {
   go: {
-    ipfsBin: findBin('go', true)
+    ipfsBin: require('go-ipfs-dep').path()
   },
   js: {
-    ipfsBin: findBin('js', true)
+    ipfsBin: require.resolve('ipfs/src/cli/bin.js')
   }
 }) // using defaults
 module.exports = {

--- a/examples/electron-asar/app.js
+++ b/examples/electron-asar/app.js
@@ -6,7 +6,7 @@ const app = electron.app
 const ipcMain = electron.ipcMain
 const BrowserWindow = electron.BrowserWindow
 
-const { createNode, createServer } = require('ipfsd-ctl')
+const { createController, createServer } = require('ipfsd-ctl')
 
 app.on('ready', () => {
   const win = new BrowserWindow({
@@ -24,7 +24,10 @@ ipcMain.on('start', async ({ sender }) => {
   try {
     const s = createServer()
     await s.start()
-    const node = await createNode({ type: 'go' })
+    const node = await createController({
+      type: 'go',
+      ipfsBin: require('go-ipfs-dep').path()
+    })
     console.log('get id')
     sender.send('message', 'get id')
 

--- a/examples/electron-asar/package.json
+++ b/examples/electron-asar/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "./app.js",
   "dependencies": {
-    "go-ipfs-dep": "~0.4.22",
+    "go-ipfs-dep": "github:ipfs/npm-go-ipfs-dep#add-path-function-to-detect-binary",
     "ipfs": "^0.39.0-rc.2",
     "ipfsd-ctl": "file:../.."
   },

--- a/examples/id/id.js
+++ b/examples/id/id.js
@@ -1,20 +1,32 @@
 /* eslint no-console: 0 */
 'use strict'
 
-const { createNode } = require('../../src')
+const { createController } = require('../../src')
 
 async function run () {
-  const node = await createNode({ type: 'go' })
+  const node = await createController({
+    type: 'go',
+    ipfsBin: require('go-ipfs-dep').path(),
+    ipfsHttpModule: require('ipfs-http-client')
+  })
   console.log('alice')
   console.log(await node.api.id())
   await node.stop()
 
-  const nodeJs = await createNode({ type: 'js' })
+  const nodeJs = await createController({
+    type: 'js',
+    ipfsBin: require.resolve('ipfs/src/cli/bin.js'),
+    ipfsHttpModule: require('ipfs-http-client')
+  })
   console.log('alice')
   console.log(await nodeJs.api.id())
   await nodeJs.stop()
 
-  const nodeProc = await createNode({ type: 'proc' })
+  const nodeProc = await createController({
+    type: 'proc',
+    ipfsModule: require('ipfs'),
+    ipfsHttpModule: require('ipfs-http-client')
+  })
   console.log('bob')
   console.log(await nodeProc.api.id())
   await nodeProc.stop()

--- a/examples/remote-disposable/remote-disposable.js
+++ b/examples/remote-disposable/remote-disposable.js
@@ -4,12 +4,16 @@
 // Start a remote disposable node, and get access to the api
 // print the node id, and stop the temporary daemon
 
-const { createNode, createServer } = require('../../src')
+const { createController, createServer } = require('../../src')
 const server = createServer()
 
 async function run () {
   await server.start()
-  const node = await createNode({ remote: true })
+  const node = await createController({
+    remote: true,
+    type: 'go',
+    ipfsBin: require('go-ipfs-dep').path()
+  })
 
   console.log(await node.api.id())
   await node.stop()

--- a/package.json
+++ b/package.json
@@ -62,7 +62,6 @@
     "merge-options": "^2.0.0",
     "multiaddr": "^7.2.1",
     "nanoid": "^2.1.9",
-    "resolve-cwd": "^3.0.0",
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
@@ -71,10 +70,10 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
-    "go-ipfs-dep": "^0.4.22",
+    "go-ipfs-dep": "github:ipfs/npm-go-ipfs-dep#add-path-function-to-detect-binary",
     "husky": "^4.0.10",
-    "ipfs": "^0.40.0",
-    "ipfs-http-client": "^42.0.0-pre.0",
+    "ipfs": "^0.41.0-rc.0",
+    "ipfs-http-client": "^42.0.0",
     "lint-staged": "^10.0.2"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -70,9 +70,9 @@
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
     "dirty-chai": "^2.0.1",
-    "go-ipfs-dep": "github:ipfs/npm-go-ipfs-dep#add-path-function-to-detect-binary",
+    "go-ipfs-dep": "github:ipfs/npm-go-ipfs-dep#master",
     "husky": "^4.0.10",
-    "ipfs": "^0.41.0-rc.0",
+    "ipfs": "^0.40.0",
     "ipfs-http-client": "^42.0.0",
     "lint-staged": "^10.0.2"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -82,13 +82,9 @@ module.exports = {
  * - proc - spawn in-process js-ipfs node
  * @property {Object} [env] - Additional environment variables, passed to executing shell. Only applies for Daemon controllers.
  * @property {Array} [args] - Custom cli args.
- * @property {Object} [ipfsHttpModule] - Setup IPFS HTTP client to be used by ctl.
- * @property {Object} [ipfsHttpModule.ref] - Reference to a IPFS HTTP Client object. (defaults to the local require(`ipfs-http-client`))
- * @property {string} [ipfsHttpModule.path] - Path to a IPFS HTTP Client to be required. (defaults to the local require.resolve('ipfs-http-client'))
- * @property {Object} [ipfsModule] - Setup IPFS API to be used by ctl.
- * @property {Object} [ipfsModule.ref] - Reference to a IPFS API object. (defaults to the local require(`ipfs`))
- * @property {string} [ipfsModule.path] - Path to a IPFS API implementation to be required. (defaults to the local require.resolve('ipfs'))
- * @property {String} [ipfsBin] - Path to a IPFS exectutable . (defaults to the local 'js-ipfs/src/bin/cli.js')
+ * @property {Object} [ipfsHttpModule] - Reference to a IPFS HTTP Client object. (defaults to the local require(`ipfs-http-client`))
+ * @property {Object} [ipfsModule] - Reference to a IPFS API object. (defaults to the local require(`ipfs`))
+ * @property {String} [ipfsBin] - Path to a IPFS exectutable
  * @property {IpfsOptions} [ipfsOptions] - Options for the IPFS node.
  * @property {boolean} [forceKill] - Whether to use SIGKILL to quit a daemon that does not stop after `.stop()` is called. (default true)
  * @property {Number} [forceKillTimeout] - How long to wait before force killing a daemon in ms. (default 5000)

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -46,7 +46,7 @@ class Client {
   _setApi (addr) {
     if (addr) {
       this.apiAddr = multiaddr(addr)
-      this.api = (this.opts.ipfsHttpModule.ref)(addr)
+      this.api = this.opts.ipfsHttpModule(addr)
       this.api.apiHost = this.apiAddr.nodeAddress().address
       this.api.apiPort = this.apiAddr.nodeAddress().port
     }

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -38,10 +38,6 @@ class Daemon {
   constructor (opts) {
     /** @type ControllerOptions */
     this.opts = opts
-    // make sure we have real paths
-    this.opts.ipfsHttpModule.path = fs.realpathSync(this.opts.ipfsHttpModule.path)
-    this.opts.ipfsBin = fs.realpathSync(this.opts.ipfsBin)
-
     this.path = this.opts.ipfsOptions.repo || (opts.disposable ? tmpDir(opts.type) : defaultRepo(opts.type))
     this.exec = this.opts.ipfsBin
     this.env = merge({ IPFS_PATH: this.path }, this.opts.env)
@@ -61,7 +57,7 @@ class Daemon {
    */
   _setApi (addr) {
     this.apiAddr = multiaddr(addr)
-    this.api = require(this.opts.ipfsHttpModule.path)(addr)
+    this.api = this.opts.ipfsHttpModule(addr)
     this.api.apiHost = this.apiAddr.nodeAddress().address
     this.api.apiPort = this.apiAddr.nodeAddress().port
   }
@@ -254,7 +250,9 @@ class Daemon {
     try {
       await this.api.stop()
     } catch (err) {
-      if (!killed) throw err // if was killed then ignore error
+      if (!killed) {
+        throw err // if was killed then ignore error
+      }
 
       daemonLog.info('Daemon was force killed')
     }

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -36,7 +36,8 @@ class InProc {
       return
     }
 
-    const IPFS = this.opts.ipfsModule.ref
+    const IPFS = this.opts.ipfsModule
+
     this.api = await IPFS.create(merge({
       silent: true,
       repo: this.path
@@ -49,7 +50,7 @@ class InProc {
    */
   _setApi (addr) {
     this.apiAddr = multiaddr(addr)
-    this.api = (this.opts.ipfsHttpModule.ref)(addr)
+    this.api = this.opts.ipfsHttpModule(addr)
     this.api.apiHost = this.apiAddr.nodeAddress().address
     this.api.apiPort = this.apiAddr.nodeAddress().port
   }
@@ -90,6 +91,7 @@ class InProc {
 
     await this.setExec()
     await this.api.init(opts)
+
     this.clean = false
     this.initialized = true
     return this

--- a/src/utils.browser.js
+++ b/src/utils.browser.js
@@ -45,9 +45,6 @@ const checkForRunningApi = (path) => {
   return null
 }
 
-const findBin = (type) => {
-}
-
 const tmpDir = (type = '') => {
   return `${type}_ipfs_${nanoid()}`
 }
@@ -57,6 +54,5 @@ module.exports = {
   repoExists,
   defaultRepo,
   checkForRunningApi,
-  findBin,
   tmpDir
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -5,8 +5,6 @@ const path = require('path')
 const fs = require('fs-extra')
 const debug = require('debug')
 const nanoid = require('nanoid')
-const resolveCwd = require('resolve-cwd')
-const isWindows = os.platform() === 'win32'
 
 const log = debug('ipfsd-ctl:utils')
 
@@ -26,7 +24,7 @@ const repoExists = async (repoPath) => {
 const defaultRepo = (type) => {
   return path.join(
     os.homedir(),
-    type === 'js' ? '.jsipfs' : '.ipfs'
+    type === 'js' || type === 'proc' ? '.jsipfs' : '.ipfs'
   )
 }
 
@@ -41,16 +39,6 @@ const checkForRunningApi = (repoPath) => {
   return api ? api.toString() : null
 }
 
-const findBin = (type, required) => {
-  const resolve = required ? resolveCwd : resolveCwd.silent
-
-  if (type === 'js') {
-    return process.env.IPFS_JS_EXEC || resolve('ipfs/src/cli/bin.js')
-  }
-
-  return process.env.IPFS_GO_EXEC || resolve(`go-ipfs-dep/go-ipfs/${isWindows ? 'ipfs.exe' : 'ipfs'}`)
-}
-
 const tmpDir = (type = '') => {
   return path.join(os.tmpdir(), `${type}_ipfs_${nanoid()}`)
 }
@@ -60,6 +48,5 @@ module.exports = {
   repoExists,
   defaultRepo,
   checkForRunningApi,
-  findBin,
   tmpDir
 }

--- a/test/browser.utils.js
+++ b/test/browser.utils.js
@@ -8,15 +8,11 @@ const expect = chai.expect
 chai.use(dirtyChai)
 
 const { isEnvWithDom } = require('ipfs-utils/src/env')
-const { findBin, tmpDir, checkForRunningApi, defaultRepo, repoExists, removeRepo } = require('../src/utils')
+const { tmpDir, checkForRunningApi, defaultRepo, repoExists, removeRepo } = require('../src/utils')
 const { createFactory, createController } = require('../src')
 
 describe('utils browser version', function () {
   if (isEnvWithDom) {
-    it('findBin should return undefined', () => {
-      expect(findBin()).to.be.undefined()
-    })
-
     it('tmpDir should return correct path', () => {
       expect(tmpDir('js')).to.be.contain('js_ipfs_')
       expect(tmpDir('go')).to.be.contain('go_ipfs_')
@@ -37,10 +33,7 @@ describe('utils browser version', function () {
         type: 'proc',
         disposable: false,
         ipfsOptions: { repo: 'ipfs_test_remove' },
-        ipfsModule: {
-          path: require.resolve('ipfs'),
-          ref: require('ipfs')
-        }
+        ipfsModule: require('ipfs')
       })
       await ctl.init()
       await ctl.start()
@@ -60,10 +53,7 @@ describe('utils browser version', function () {
           ipfsOptions: {
             repo: 'ipfs_test'
           },
-          ipfsModule: {
-            path: require.resolve('ipfs'),
-            ref: require('ipfs')
-          }
+          ipfsModule: require('ipfs')
         })
         expect(await repoExists('ipfs_test')).to.be.true()
         await node.stop()

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -7,7 +7,7 @@ const dirtyChai = require('dirty-chai')
 const chaiPromise = require('chai-as-promised')
 const { createFactory, createController } = require('../src')
 const { repoExists } = require('../src/utils')
-const { isBrowser, isWebWorker } = require('ipfs-utils/src/env')
+const { isBrowser, isWebWorker, isNode } = require('ipfs-utils/src/env')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -47,7 +47,9 @@ const types = [{
   }
 }]
 
-describe('Controller API', () => {
+describe('Controller API', function () {
+  this.timeout(60000)
+
   const factory = createFactory({
     test: true,
     ipfsHttpModule: require('ipfs-http-client')
@@ -60,7 +62,7 @@ describe('Controller API', () => {
       ipfsModule: require('ipfs')
     },
     go: {
-      ipfsBin: require('go-ipfs-dep').path()
+      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined
     }
   })
 

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -33,7 +33,7 @@ describe('`createController` should return the correct class', () => {
       type: 'go',
       disposable: false,
       ipfsHttpModule: require('ipfs-http-client'),
-      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined
     })
 
     if (!isNode) {

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -33,7 +33,7 @@ describe('`createController` should return the correct class', () => {
       type: 'go',
       disposable: false,
       ipfsHttpModule: require('ipfs-http-client'),
-      ipfsBin: require('go-ipfs-dep').path()
+      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
     })
 
     if (!isNode) {
@@ -73,7 +73,7 @@ const types = [{
   ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: require('go-ipfs-dep').path(),
+  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
   type: 'go',
   test: true
 }, {
@@ -90,7 +90,7 @@ const types = [{
   ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: require('go-ipfs-dep').path(),
+  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
   type: 'go',
   test: true,
   remote: true

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -8,7 +8,6 @@ const { createFactory, createController, createServer } = require('../src')
 const Client = require('../src/ipfsd-client')
 const Daemon = require('../src/ipfsd-daemon')
 const Proc = require('../src/ipfsd-in-proc')
-const { findBin } = require('../src/utils')
 
 const expect = chai.expect
 chai.use(dirtyChai)
@@ -18,15 +17,9 @@ describe('`createController` should return the correct class', () => {
     const f = await createController({
       type: 'js',
       disposable: false,
-      ipfsModule: {
-        path: require.resolve('ipfs'),
-        ref: require('ipfs')
-      },
-      ipfsHttpModule: {
-        path: require.resolve('ipfs-http-client'),
-        ref: require('ipfs-http-client')
-      },
-      ipfsBin: findBin('js', true)
+      ipfsModule: require('ipfs'),
+      ipfsHttpModule: require('ipfs-http-client'),
+      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
     })
 
     if (!isNode) {
@@ -39,11 +32,8 @@ describe('`createController` should return the correct class', () => {
     const f = await createController({
       type: 'go',
       disposable: false,
-      ipfsHttpModule: {
-        path: require.resolve('ipfs-http-client'),
-        ref: require('ipfs-http-client')
-      },
-      ipfsBin: findBin('go', true)
+      ipfsHttpModule: require('ipfs-http-client'),
+      ipfsBin: require('go-ipfs-dep').path()
     })
 
     if (!isNode) {
@@ -62,15 +52,9 @@ describe('`createController` should return the correct class', () => {
     const f = await createController({
       remote: true,
       disposable: false,
-      ipfsModule: {
-        path: require.resolve('ipfs'),
-        ref: require('ipfs')
-      },
-      ipfsHttpModule: {
-        path: require.resolve('ipfs-http-client'),
-        ref: require('ipfs-http-client')
-      },
-      ipfsBin: findBin('js', true)
+      ipfsModule: require('ipfs'),
+      ipfsHttpModule: require('ipfs-http-client'),
+      ipfsBin: require.resolve('ipfs/src/cli/bin.js')
     })
 
     expect(f).to.be.instanceOf(Client)
@@ -78,38 +62,35 @@ describe('`createController` should return the correct class', () => {
 })
 
 const defaultOps = {
-  ipfsModule: {
-    path: require.resolve('ipfs'),
-    ref: require('ipfs')
-  },
-  ipfsHttpModule: {
-    path: require.resolve('ipfs-http-client'),
-    ref: require('ipfs-http-client')
-  },
-  ipfsBin: findBin('js', true)
+  ipfsHttpModule: require('ipfs-http-client')
 }
 
 const types = [{
   ...defaultOps,
   type: 'js',
-  test: true
+  test: true,
+  ipfsModule: require('ipfs'),
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: findBin('go', true),
+  ipfsBin: require('go-ipfs-dep').path(),
   type: 'go',
   test: true
 }, {
   ...defaultOps,
   type: 'proc',
-  test: true
+  test: true,
+  ipfsModule: require('ipfs')
 }, {
   ...defaultOps,
   type: 'js',
   test: true,
-  remote: true
+  remote: true,
+  ipfsModule: require('ipfs'),
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: findBin('go', true),
+  ipfsBin: require('go-ipfs-dep').path(),
   type: 'go',
   test: true,
   remote: true

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -21,7 +21,7 @@ const types = [{
   ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: require('go-ipfs-dep').path(),
+  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
   type: 'go',
   test: true
 }, {
@@ -38,7 +38,7 @@ const types = [{
   ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: require('go-ipfs-dep').path(),
+  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
   type: 'go',
   remote: true,
   test: true

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -68,7 +68,7 @@ describe('`Factory tmpDir()` should return correct temporary dir', () => {
 })
 
 describe('`Factory spawn()` ', function () {
-  this.timeout(10000)
+  this.timeout(60000)
 
   describe('should return a node with api', () => {
     for (const opts of types) {

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -5,44 +5,40 @@ const chai = require('chai')
 const dirtyChai = require('dirty-chai')
 const { isNode } = require('ipfs-utils/src/env')
 const { createFactory } = require('../src')
-const { findBin } = require('../src/utils')
 
 const expect = chai.expect
 chai.use(dirtyChai)
 
 const defaultOps = {
-  ipfsModule: {
-    path: require.resolve('ipfs'),
-    ref: require('ipfs')
-  },
-  ipfsHttpModule: {
-    path: require.resolve('ipfs-http-client'),
-    ref: require('ipfs-http-client')
-  },
-  ipfsBin: findBin('js', true)
+  ipfsHttpModule: require('ipfs-http-client')
 }
 
 const types = [{
   ...defaultOps,
   type: 'js',
-  test: true
+  test: true,
+  ipfsModule: require('ipfs'),
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: findBin('go', true),
+  ipfsBin: require('go-ipfs-dep').path(),
   type: 'go',
   test: true
 }, {
   ...defaultOps,
   type: 'proc',
-  test: true
+  test: true,
+  ipfsModule: require('ipfs')
 }, {
   ...defaultOps,
   type: 'js',
   remote: true,
-  test: true
+  test: true,
+  ipfsModule: require('ipfs'),
+  ipfsBin: require.resolve('ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: findBin('go', true),
+  ipfsBin: require('go-ipfs-dep').path(),
   type: 'go',
   remote: true,
   test: true
@@ -71,7 +67,9 @@ describe('`Factory tmpDir()` should return correct temporary dir', () => {
   }
 })
 
-describe('`Factory spawn()` ', () => {
+describe('`Factory spawn()` ', function () {
+  this.timeout(10000)
+
   describe('should return a node with api', () => {
     for (const opts of types) {
       it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
@@ -92,15 +90,9 @@ describe('`Factory spawn()` ', () => {
         const ctl = await factory.spawn({
           type: opts.type,
           remote: opts.remote,
-          ipfsModule: {
-            path: require.resolve('ipfs'),
-            ref: require('ipfs')
-          },
-          ipfsHttpModule: {
-            path: require.resolve('ipfs-http-client'),
-            ref: require('ipfs-http-client')
-          },
-          ipfsBin: findBin('js', true)
+          ipfsModule: require('ipfs'),
+          ipfsHttpModule: require('ipfs-http-client'),
+          ipfsBin: require.resolve('ipfs/src/cli/bin.js')
         })
         expect(ctl).to.exist()
         expect(ctl.opts.test).to.be.true()
@@ -150,7 +142,7 @@ describe('`Factory spawn()` ', () => {
     }
   })
 
-  describe('`Factory.clean()` should not error when controller already stop', () => {
+  describe('`Factory.clean()` should not error when controller already stopped', () => {
     for (const opts of types) {
       it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
         const factory = createFactory(opts)

--- a/test/node.routes.js
+++ b/test/node.routes.js
@@ -18,14 +18,8 @@ describe('routes', () => {
     server = new Hapi.Server({ port: 43134 })
     routes(server, () => {
       return createFactory({
-        ipfsModule: {
-          path: require.resolve('ipfs'),
-          ref: require('ipfs')
-        },
-        ipfsHttpModule: {
-          path: require.resolve('ipfs-http-client'),
-          ref: require('ipfs-http-client')
-        },
+        ipfsModule: require('ipfs'),
+        ipfsHttpModule: require('ipfs-http-client'),
         ipfsBin: require.resolve('ipfs/src/cli/bin.js')
       })
     })

--- a/test/node.utils.js
+++ b/test/node.utils.js
@@ -7,32 +7,13 @@ const dirtyChai = require('dirty-chai')
 const os = require('os')
 const path = require('path')
 
-const isWindows = os.platform() === 'win32'
 const expect = chai.expect
 chai.use(dirtyChai)
 
-const { findBin, tmpDir, checkForRunningApi, defaultRepo, repoExists, removeRepo } = require('../src/utils')
+const { tmpDir, checkForRunningApi, defaultRepo, repoExists, removeRepo } = require('../src/utils')
 const { createFactory, createController } = require('../src')
 
 describe('utils node version', function () {
-  describe('findBin', () => {
-    it('should return from process.env', () => {
-      process.env.IPFS_JS_EXEC = 'js-ipfs'
-      process.env.IPFS_GO_EXEC = 'go-ipfs'
-      expect(findBin('js')).to.be.eq('js-ipfs')
-      expect(findBin('go')).to.be.eq('go-ipfs')
-      delete process.env.IPFS_JS_EXEC
-      delete process.env.IPFS_GO_EXEC
-    })
-    it('should return from node modules', () => {
-      expect(findBin('js')).to.be.contain(path.join('node_modules', 'ipfs', 'src', 'cli', 'bin.js'))
-      expect(findBin('go')).to.be.contain(path.join('node_modules', 'go-ipfs-dep', 'go-ipfs', 'ipfs'))
-      if (isWindows) {
-        expect(findBin('go')).to.be.contain(path.join('node_modules', 'go-ipfs-dep', 'go-ipfs', 'ipfs.exe'))
-      }
-    })
-  })
-
   it('tmpDir should return correct path', () => {
     expect(tmpDir('js')).to.be.contain(path.join(os.tmpdir(), 'js_ipfs_'))
     expect(tmpDir('go')).to.be.contain(path.join(os.tmpdir(), 'go_ipfs_'))
@@ -46,14 +27,8 @@ describe('utils node version', function () {
     it('should return path to api with running node', async () => {
       const node = await createController({
         test: true,
-        ipfsModule: {
-          path: require.resolve('ipfs'),
-          ref: require('ipfs')
-        },
-        ipfsHttpModule: {
-          path: require.resolve('ipfs-http-client'),
-          ref: require('ipfs-http-client')
-        },
+        ipfsModule: require('ipfs'),
+        ipfsHttpModule: require('ipfs-http-client'),
         ipfsBin: require.resolve('ipfs/src/cli/bin.js')
       })
       expect(checkForRunningApi(node.path)).to.be.contain('/ip4/127.0.0.1/tcp/')
@@ -70,14 +45,8 @@ describe('utils node version', function () {
   it('removeRepo should work', async () => {
     const f = createFactory({
       test: true,
-      ipfsModule: {
-        path: require.resolve('ipfs'),
-        ref: require('ipfs')
-      },
-      ipfsHttpModule: {
-        path: require.resolve('ipfs-http-client'),
-        ref: require('ipfs-http-client')
-      },
+      ipfsModule: require('ipfs'),
+      ipfsHttpModule: require('ipfs-http-client'),
       ipfsBin: require.resolve('ipfs/src/cli/bin.js')
     })
     const dir = await f.tmpDir()
@@ -98,14 +67,8 @@ describe('utils node version', function () {
       const node = await createController({
         type: 'proc',
         test: true,
-        ipfsModule: {
-          path: require.resolve('ipfs'),
-          ref: require('ipfs')
-        },
-        ipfsHttpModule: {
-          path: require.resolve('ipfs-http-client'),
-          ref: require('ipfs-http-client')
-        },
+        ipfsModule: require('ipfs'),
+        ipfsHttpModule: require('ipfs-http-client'),
         ipfsBin: require.resolve('ipfs/src/cli/bin.js')
       })
       expect(await repoExists(node.path)).to.be.true()


### PR DESCRIPTION
Since we're not passing modules to `.spawn()` there's no danger of passing module refs over http, so we can remove the `.path` and `.ref` arguments when specifying which `ipfs-http-client` and `ipfs` modules to use, instead setting them up when you configure the daemon factory, either in-proc or as a server in an `.aegir` file.

Also removes the `findBin` command magic in favour of being explicit about which binary you want the factory to use.

If you need to support env vars like `IPFS_GO_EXEC`, do that when you set up the factory, for example:

```javascript
const factory = createFactory({
  ipfsBin: process.env.IPFS_GO_EXEC || require('go-ipfs-dep').path()
})
```

Also fixes up the examples and upgrades the `ipfs` dep to run tests against the async/await refactor.

BREAKING CHANGES:

- `.path` and `.ref` args removed from `ipfsModule` and `ipfsHttpModule`
- `findBin` function removed