### PR TITLE
feat: remove default key size and upgrade go-ipfs-dep

### DIFF
--- a/examples/electron-asar/package.json
+++ b/examples/electron-asar/package.json
@@ -3,8 +3,8 @@
   "private": true,
   "main": "./app.js",
   "dependencies": {
-    "go-ipfs-dep": "github:ipfs/npm-go-ipfs-dep#add-path-function-to-detect-binary",
-    "ipfs": "^0.39.0-rc.2",
+    "go-ipfs-dep": "^0.5.0",
+    "ipfs": "^0.43.0",
     "ipfsd-ctl": "file:../.."
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "devDependencies": {
     "aegir": "^21.9.0",
     "benchmark": "^2.1.4",
-    "go-ipfs-dep": "^0.4.23-3",
+    "go-ipfs-dep": "^0.5.0",
     "husky": "^4.2.5",
     "ipfs": "^0.43.0",
     "ipfs-http-client": "^44.0.0",

--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -77,7 +77,6 @@ class Client {
     const opts = merge(
       {
         emptyRepo: false,
-        bits: this.opts.test ? 1024 : 2048,
         profiles: this.opts.test ? ['test'] : []
 
       },

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -88,7 +88,6 @@ class Daemon {
     const opts = merge(
       {
         emptyRepo: false,
-        bits: this.opts.test ? 1024 : 2048,
         profiles: this.opts.test ? ['test'] : []
       },
       typeof this.opts.ipfsOptions.init === 'boolean' ? {} : this.opts.ipfsOptions.init,

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -82,7 +82,6 @@ class InProc {
     const opts = merge(
       {
         emptyRepo: false,
-        bits: this.opts.test ? 1024 : 2048,
         profiles: this.opts.test ? ['test'] : []
       },
       typeof this.opts.ipfsOptions.init === 'boolean' ? {} : this.opts.ipfsOptions.init,

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -7,22 +7,6 @@ const suite = new Benchmark.Suite()
 const { createNodeTests } = require('../src')
 
 suite
-  .add('ctl go 1024', {
-    defer: true,
-    fn: async (deferred) => {
-      const node = await createNodeTests({
-        type: 'go',
-        ipfsOptions: {
-          init: {
-            bits: 1024
-          }
-        }
-      })
-
-      await node.stop()
-      deferred.resolve()
-    }
-  })
   .add('ctl go 2048', {
     defer: true,
     fn: async (deferred) => {
@@ -31,38 +15,6 @@ suite
         ipfsOptions: {
           init: {
             bits: 2048
-          }
-        }
-      })
-
-      await node.stop()
-      deferred.resolve()
-    }
-  })
-  .add('ctl js 512', {
-    defer: true,
-    fn: async (deferred) => {
-      const node = await createNodeTests({
-        type: 'js',
-        ipfsOptions: {
-          init: {
-            bits: 512
-          }
-        }
-      })
-
-      await node.stop()
-      deferred.resolve()
-    }
-  })
-  .add('ctl js 1024', {
-    defer: true,
-    fn: async (deferred) => {
-      const node = await createNodeTests({
-        type: 'js',
-        ipfsOptions: {
-          init: {
-            bits: 1024
           }
         }
       })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -110,14 +110,14 @@ describe('Controller API', function () {
           if (opts.type === 'js') {
             await expect(ctl.init({
               emptyRepo: true,
-              bits: 1024,
+              bits: 2048,
               profile: ['test'],
               pass: 'QmfPjo1bKmpcdWxpQnGAKjeae9F9aCxTDiS61t9a3hmvRi'
             })).to.be.fulfilled()
           } else {
             await expect(ctl.init({
               emptyRepo: true,
-              bits: 1024,
+              bits: 2048,
               profile: ['test']
             })).to.be.fulfilled()
           }


### PR DESCRIPTION
`go-ipfs@0.5.0` doesn't support keys < 2048 so let the implementation decide what the default key size should be.

The value is overridable as before by setting `ipfsOptions.init.bits` in the node setup.