### PR TITLE
fix: remove onBlocked hook from delete database

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^21.10.2",
+    "aegir": "^22.0.0",
     "benchmark": "^2.1.4",
     "go-ipfs-dep": "^0.5.0",
     "husky": "^4.2.5",

--- a/src/utils.browser.js
+++ b/src/utils.browser.js
@@ -1,10 +1,20 @@
 'use strict'
 const { nanoid } = require('nanoid')
 
-const deleteDb = (path) => {
+const deleteDb = (path, retries = 1) => {
   return new Promise((resolve, reject) => {
     const keys = self.indexedDB.deleteDatabase(path)
-    keys.onblocked = () => reject(new Error('Database is still open.'))
+    keys.onblocked = () => {
+      if (retries === 6) {
+        reject(new Error('Database is still open.'))
+        return
+      }
+
+      setTimeout(() => {
+        deleteDb(path, retries++)
+          .then(resolve, reject)
+      }, retries * 1000)
+    }
     keys.onerror = (err) => reject(err)
     keys.onsuccess = () => resolve()
   })

--- a/src/utils.browser.js
+++ b/src/utils.browser.js
@@ -1,20 +1,9 @@
 'use strict'
 const { nanoid } = require('nanoid')
 
-const deleteDb = (path, retries = 1) => {
+const deleteDb = (path) => {
   return new Promise((resolve, reject) => {
     const keys = self.indexedDB.deleteDatabase(path)
-    keys.onblocked = () => {
-      if (retries === 6) {
-        reject(new Error('Database is still open.'))
-        return
-      }
-
-      setTimeout(() => {
-        deleteDb(path, retries++)
-          .then(resolve, reject)
-      }, retries * 1000)
-    }
     keys.onerror = (err) => reject(err)
     keys.onsuccess = () => resolve()
   })

--- a/test/browser.utils.js
+++ b/test/browser.utils.js
@@ -40,6 +40,28 @@ describe('utils browser version', function () {
       expect(await repoExists('ipfs_test_remove/datastore')).to.be.false()
     })
 
+    it('removeRepo should wait for db to be closed', async () => {
+      const ctl = await createController({
+        test: true,
+        type: 'proc',
+        disposable: false,
+        ipfsOptions: { repo: 'ipfs_test_remove' },
+        ipfsModule: require('ipfs')
+      })
+      await ctl.init()
+      await ctl.start()
+
+      await Promise.all([
+        removeRepo('ipfs_test_remove'),
+        ctl.stop()
+      ])
+
+      expect(await repoExists('ipfs_test_remove')).to.be.false()
+      expect(await repoExists('ipfs_test_remove/keys')).to.be.false()
+      expect(await repoExists('ipfs_test_remove/blocks')).to.be.false()
+      expect(await repoExists('ipfs_test_remove/datastore')).to.be.false()
+    })
+
     describe('repoExists', () => {
       it('should resolve true when repo exists', async () => {
         const f = createFactory({ test: true })


### PR DESCRIPTION
If we try to shut a node down while a query is still in flight it errors out.  The change here is to retry deleting the databse when we detect that it's still open, 5x attempts, each waiting 1-5s before trying again.  If it's still open after that, bail.