### PR TITLE
feat: swap go-ipfs-dep for go-ipfs

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -3,14 +3,14 @@
 const getPort = require('aegir/utils/get-port')
 const createServer = require('./src').createServer
 
-const server = createServer(undefined, 
+const server = createServer(undefined,
   {
     ipfsModule: require('ipfs'),
     ipfsHttpModule: require('ipfs-http-client')
-  }, 
+  },
   {
     go: {
-      ipfsBin: require('go-ipfs-dep').path()
+      ipfsBin: require('go-ipfs').path()
     },
     js: {
       ipfsBin: require.resolve('ipfs/src/cli/bin.js')

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@
 
 ### Features
 
-* remove default key size and upgrade go-ipfs-dep ([#504](https://github.com/ipfs/js-ipfsd-ctl/issues/504)) ([ecbf4be](https://github.com/ipfs/js-ipfsd-ctl/commit/ecbf4be))
+* remove default key size and upgrade go-ipfs ([#504](https://github.com/ipfs/js-ipfsd-ctl/issues/504)) ([ecbf4be](https://github.com/ipfs/js-ipfsd-ctl/commit/ecbf4be))
 
 
 
@@ -91,7 +91,7 @@
 
 * chore: increase test timeouts
 
-* fix: only get go-ipfs-dep path in node
+* fix: only get go-ipfs path in node
 
 * fix: linting
 
@@ -192,7 +192,7 @@ to use js-IPFS.
 
 ### BREAKING CHANGES
 
-* Problems: 
+* Problems:
 - Browsers tests skipped cause ctl didn't support proper connectivity to remote nodes
 - We weren't able to tell ctl to use a specific commit of http-client, js-ipfs or cli
 - Options/config between the 3 types of daemons weren't consistent
@@ -206,8 +206,8 @@ Related issues:
 - https://github.com/ipfs/js-ipfsd-ctl/issues/315
 - https://github.com/ipfs/js-ipfsd-ctl/issues/207
 - https://github.com/ipfs/js-ipfsd-ctl/issues/217
-- and more 
- 
+- and more
+
 Improvements:
 - better errors
 - DEBUG='ipfsd-ctl:*' everywhere
@@ -228,14 +228,14 @@ Improvements:
 - support electron
 - test in electron
 
-New: 
+New:
 - new method `createController` returns a spawned controller
 - createFactory as a second parameter to override options per type
 
 
-Changes: 
+Changes:
 - `create` change to `createFactory`
-- `createFactory` options changed   
+- `createFactory` options changed
 
 Old
 ```md
@@ -272,7 +272,7 @@ Old
 ```
 
 - Previous default ipfs config is only applied when `test` options equals `true`
-- `defaultAddrs` option was removed 
+- `defaultAddrs` option was removed
 - Spawn options are the same as `createFactory`
 
 Old

--- a/README.md
+++ b/README.md
@@ -32,17 +32,17 @@ Version 1.0.0 changed a bit the api and the options methods take so please read 
 npm install --save ipfsd-ctl
 ```
 
-Please ensure your project also has dependencies on `ipfs`, `ipfs-http-client` and `go-ipfs-dep`.
+Please ensure your project also has dependencies on `ipfs`, `ipfs-http-client` and `go-ipfs`.
 
 ```sh
 npm install --save ipfs
 npm install --save ipfs-http-client
-npm install --save go-ipfs-dep
+npm install --save go-ipfs
 ```
 
 If you are only going to use the `go` implementation of IPFS, you can skip installing the `js` implementation and vice versa, though both will require the `ipfs-http-client` module.
 
-If you are only using the `proc` type in-process IPFS node, you can skip installing `go-ipfs-dep` and `ipfs-http-client`.
+If you are only using the `proc` type in-process IPFS node, you can skip installing `go-ipfs` and `ipfs-http-client`.
 
 > You also need to explicitly defined the options `ipfsBin`, `ipfsModule` and `ipfsHttpModule` according to your needs.  Check [ControllerOptions](#controlleroptions) and [ControllerOptionsOverrides](#controlleroptionsoverrides) for more information.
 
@@ -58,7 +58,7 @@ This is a shorthand for simpler use cases where factory is not needed.
 const Ctl = require('ipfsd-ctl')
 const ipfsd = await Ctl.createController({
     ipfsHttpModule: require('ipfs-http-client'),
-    ipfsBin: require('go-ipfs-dep').path()
+    ipfsBin: require('go-ipfs').path()
 })
 const id = await ipfsd.api.id()
 
@@ -79,9 +79,9 @@ Use a factory to spawn multiple controllers based on some common template.
 const Ctl = require('ipfsd-ctl')
 
 const factory = Ctl.createFactory(
-    { 
-        type: 'js', 
-        test: true, 
+    {
+        type: 'js',
+        test: true,
         disposable: true,
         ipfsHttpModule: require('ipfs-http-client'),
         ipfsModule: require('ipfs') // only if you gonna spawn 'proc' controllers
@@ -127,7 +127,7 @@ const server = Ctl.createServer(port, {
 })
 const factory = Ctl.createFactory({
     ipfsHttpModule: require('ipfs-http-client'),
-    remote: true, 
+    remote: true,
     endpoint: `http://localhost:${port}` // or you can set process.env.IPFSD_CTL_SERVER to http://localhost:9090
 })
 

--- a/examples/electron-asar/app.js
+++ b/examples/electron-asar/app.js
@@ -26,7 +26,7 @@ ipcMain.on('start', async ({ sender }) => {
     await s.start()
     const node = await createController({
       type: 'go',
-      ipfsBin: require('go-ipfs-dep').path()
+      ipfsBin: require('go-ipfs').path()
     })
     console.log('get id')
     sender.send('message', 'get id')

--- a/examples/electron-asar/package.json
+++ b/examples/electron-asar/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "main": "./app.js",
   "dependencies": {
-    "go-ipfs-dep": "^0.5.0",
+    "go-ipfs": "^0.6.0",
     "ipfs": "^0.43.0",
     "ipfsd-ctl": "file:../.."
   },

--- a/examples/id/id.js
+++ b/examples/id/id.js
@@ -6,7 +6,7 @@ const { createController } = require('../../src')
 async function run () {
   const node = await createController({
     type: 'go',
-    ipfsBin: require('go-ipfs-dep').path(),
+    ipfsBin: require('go-ipfs').path(),
     ipfsHttpModule: require('ipfs-http-client')
   })
   console.log('alice')

--- a/examples/remote-disposable/remote-disposable.js
+++ b/examples/remote-disposable/remote-disposable.js
@@ -12,7 +12,7 @@ async function run () {
   const node = await createController({
     remote: true,
     type: 'go',
-    ipfsBin: require('go-ipfs-dep').path()
+    ipfsBin: require('go-ipfs').path()
   })
 
   console.log(await node.api.id())

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "./src/endpoint/server.js": "./src/endpoint/server.browser.js",
     "./src/utils.js": "./src/utils.browser.js",
     "./src/ipfsd-daemon.js": "./src/ipfsd-client.js",
-    "go-ipfs-dep": false
+    "go-ipfs": false
   },
   "husky": {
     "hooks": {
@@ -65,14 +65,14 @@
   "devDependencies": {
     "aegir": "^23.0.0",
     "benchmark": "^2.1.4",
-    "go-ipfs-dep": "^0.5.0",
+    "go-ipfs": "^0.6.0",
     "husky": "^4.2.5",
     "ipfs": "^0.43.0",
     "ipfs-http-client": "^44.0.0",
     "lint-staged": "^10.1.6"
   },
   "peerDependencies": {
-    "go-ipfs-dep": "*",
+    "go-ipfs": "*",
     "ipfs": "*",
     "ipfs-http-client": "*"
   },

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -56,7 +56,7 @@ describe('Controller API', function () {
       ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
     },
     go: {
-      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined
+      ipfsBin: isNode ? require('go-ipfs').path() : undefined
     }
   })
 

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -30,7 +30,7 @@ describe('`createController` should return the correct class', () => {
       type: 'go',
       disposable: false,
       ipfsHttpModule: require('ipfs-http-client'),
-      ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined
+      ipfsBin: isNode ? require('go-ipfs').path() : undefined
     })
 
     if (!isNode) {
@@ -70,7 +70,7 @@ const types = [{
   ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+  ipfsBin: isNode ? require('go-ipfs').path() : undefined,
   type: 'go',
   test: true
 }, {
@@ -87,7 +87,7 @@ const types = [{
   ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+  ipfsBin: isNode ? require('go-ipfs').path() : undefined,
   type: 'go',
   test: true,
   remote: true

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -18,7 +18,7 @@ const types = [{
   ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+  ipfsBin: isNode ? require('go-ipfs').path() : undefined,
   type: 'go',
   test: true
 }, {
@@ -35,7 +35,7 @@ const types = [{
   ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
 }, {
   ...defaultOps,
-  ipfsBin: isNode ? require('go-ipfs-dep').path() : undefined,
+  ipfsBin: isNode ? require('go-ipfs').path() : undefined,
   type: 'go',
   remote: true,
   test: true

--- a/test/node.js
+++ b/test/node.js
@@ -12,7 +12,7 @@ describe('Node specific tests', function () {
     test: true,
     ipfsHttpModule: require('ipfs-http-client'),
     ipfsModule: require('ipfs'),
-    ipfsBin: require('go-ipfs-dep').path()
+    ipfsBin: require('go-ipfs').path()
   })
 
   it('should use process.IPFS_PATH', async () => {


### PR DESCRIPTION
The `go-ipfs` module does exactly what `go-ipfs-dep` does except it's got a much better name.

The plan is to encourage people to use `go-ipfs` instead as there's no need for us to maintain both.

BREAKING CHANGE:

- Previously dependent projects should also depend on `go-ipfs-dep`, now they should depend on `go-ipfs` instead