### PR TITLE
Always await daemon subprocess

### DIFF
--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -246,11 +246,21 @@ class Daemon {
       }, this.opts.forceKillTimeout)
     }
 
+    let stoppingErr
+
     try {
       await this.api.stop()
     } catch (err) {
+      // store for possible later use
+      stoppingErr = err
+    }
+
+    try {
+      // awaiting subprocesses should allow reaping any handles node vm has open for them
+      await this.subprocess
+    } catch (err) {
       if (!killed) {
-        throw err // if was killed then ignore error
+        throw stoppingErr || err // if was killed then ignore error
       }
 
       daemonLog.info('Daemon was force killed')


### PR DESCRIPTION
The idea is to always end up awaiting the subprocess even when the subprocess was killed. Not sure how correct the implementation is. Ok to supercede with another PR if you can see a better way to implement this. Pushing to run CI tests.

Fixes #525.