### PR TITLE
chore: update deps

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -38,5 +38,14 @@ module.exports = {
         }
       },
       post: () => server.stop()
+  },
+  webpack: {
+    node: {
+      // needed by ipfs-repo-migrations
+      path: true,
+
+      // needed by abstract-leveldown
+      Buffer: true
+    }
   }
 }

--- a/package.json
+++ b/package.json
@@ -58,17 +58,17 @@
     "fs-extra": "^9.0.0",
     "ipfs-utils": "^2.2.0",
     "merge-options": "^2.0.0",
-    "multiaddr": "^7.2.1",
+    "multiaddr": "^8.0.0",
     "nanoid": "^3.1.3",
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^23.0.0",
+    "aegir": "^25.0.0",
     "benchmark": "^2.1.4",
     "go-ipfs": "^0.6.0",
     "husky": "^4.2.5",
-    "ipfs": "^0.43.0",
-    "ipfs-http-client": "^44.0.0",
+    "ipfs": "^0.48.2",
+    "ipfs-http-client": "^45.0.0",
     "lint-staged": "^10.1.6"
   },
   "peerDependencies": {


### PR DESCRIPTION
BREAKING CHANGE

- Updates multiaddr to a version that uses only Uint8Arrays instead of node Buffers