### PR TITLE
chore: update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,25 +50,25 @@
     "daemon"
   ],
   "dependencies": {
-    "@hapi/boom": "^8.0.1",
-    "@hapi/hapi": "^18.4.1",
-    "@hapi/joi": "^17.1.1",
+    "@hapi/boom": "^9.1.0",
+    "@hapi/hapi": "^20.0.0",
     "debug": "^4.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0",
-    "ipfs-utils": "^2.2.0",
-    "merge-options": "^2.0.0",
+    "ipfs-utils": "^3.0.0",
+    "joi": "^17.2.1",
+    "merge-options": "^3.0.1",
     "multiaddr": "^8.0.0",
     "nanoid": "^3.1.3",
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^25.0.0",
+    "aegir": "^26.0.0",
     "benchmark": "^2.1.4",
     "go-ipfs": "^0.6.0",
     "husky": "^4.2.5",
-    "ipfs": "^0.48.2",
-    "ipfs-http-client": "^45.0.0",
+    "ipfs": "^0.49.1",
+    "ipfs-http-client": "^46.0.1",
     "lint-staged": "^10.1.6"
   },
   "peerDependencies": {

--- a/src/endpoint/routes.js
+++ b/src/endpoint/routes.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { nanoid } = require('nanoid')
-const Joi = require('@hapi/joi')
+const Joi = require('joi')
 const boom = require('@hapi/boom')
 const debug = require('debug')('ipfsd-ctl:routes')
 const { tmpDir } = require('../utils')


### PR DESCRIPTION
Updates hapi to the latest version

BREAKING CHANGES:

- Hapi has dropped support for node < 12