### PR TITLE
fix: allow enabling sharding

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "husky": "^4.2.5",
     "ipfs": "^0.49.1",
     "ipfs-http-client": "^46.0.1",
+    "ipfs-unixfs": "^2.0.3",
     "lint-staged": "^10.1.6"
   },
   "peerDependencies": {

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -170,7 +170,7 @@ class Daemon {
     if (opts.preload && this.opts.type === 'js') {
       args.push('--enable-preload', Boolean(opts.preload.enabled))
     }
-    if (opts.EXPERIMENTAL && opts.EXPERIMENTAL.sharding) {
+    if (opts.EXPERIMENTAL && opts.EXPERIMENTAL.sharding && this.opts.type === 'js') {
       args.push('--enable-sharding-experiment')
     }
     if (opts.EXPERIMENTAL && opts.EXPERIMENTAL.ipnsPubsub) {


### PR DESCRIPTION
The `--enable-sharding-experiment` CLI arg causes go-ipfs to explode, instead set it as part of the config file.