### PR TITLE
feat: go-ipfs 0.7.0 compatibility

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -45,7 +45,10 @@ module.exports = {
       path: true,
 
       // needed by abstract-leveldown
-      Buffer: true
+      Buffer: true,
+
+      // needed by nofilter
+      stream: true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -65,10 +65,10 @@
   "devDependencies": {
     "aegir": "^26.0.0",
     "benchmark": "^2.1.4",
-    "go-ipfs": "^0.6.0",
+    "go-ipfs": "^0.7.0",
     "husky": "^4.2.5",
-    "ipfs": "^0.49.1",
-    "ipfs-http-client": "^46.0.1",
+    "ipfs": "^0.50.2",
+    "ipfs-http-client": "^47.0.1",
     "ipfs-unixfs": "^2.0.3",
     "lint-staged": "^10.1.6"
   },

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -11,12 +11,7 @@ suite
     defer: true,
     fn: async (deferred) => {
       const node = await createNodeTests({
-        type: 'go',
-        ipfsOptions: {
-          init: {
-            bits: 2048
-          }
-        }
+        type: 'go'
       })
 
       await node.stop()

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -110,14 +110,12 @@ describe('Controller API', function () {
           if (opts.type === 'js') {
             await expect(ctl.init({
               emptyRepo: true,
-              bits: 2048,
               profile: ['test'],
               pass: 'QmfPjo1bKmpcdWxpQnGAKjeae9F9aCxTDiS61t9a3hmvRi'
             })).to.be.fulfilled()
           } else {
             await expect(ctl.init({
               emptyRepo: true,
-              bits: 2048,
               profile: ['test']
             })).to.be.fulfilled()
           }


### PR DESCRIPTION
Removes `bits` option when initting go-ipfs repos as the move to ed25519 keys makes it throw when `bits` is passed.