### PR TITLE
fix: use native fetch if available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,13 +47,11 @@ jobs:
 
     - stage: test
       name: electron-main
-      os: osx
       script:
         - npx aegir test -t electron-main --bail --timeout 60000
 
     - stage: test
       name: electron-renderer
-      os: osx
       script:
         - npx aegir test -t electron-renderer --bail --timeout 60000
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ branches:
   only:
   - master
   - /^release\/.*$/
+services:
+  - xvfb
 stages:
   - check
   - test

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "debug": "^4.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0",
-    "ipfs-utils": "ipfs/js-ipfs-utils#fix/use-native-fetch-if-available",
+    "ipfs-utils": "^4.0.0",
     "joi": "^17.2.1",
     "merge-options": "^3.0.1",
     "multiaddr": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "debug": "^4.1.1",
     "execa": "^4.0.0",
     "fs-extra": "^9.0.0",
-    "ipfs-utils": "^3.0.0",
+    "ipfs-utils": "ipfs/js-ipfs-utils#fix/use-native-fetch-if-available",
     "joi": "^17.2.1",
     "merge-options": "^3.0.1",
     "multiaddr": "^8.0.0",


### PR DESCRIPTION
If you are in the Electron Renderer process, native fetch is available but it's ignored because the renderer does not respect the browser field of package.json, so we end up with node-fetch that uses a browser polyfill of the node http api.

Instead use native fetch if it's available or node fetch if not.