### PR TITLE
fix: kill disposable nodes on stop and simplify started status

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "lint": "aegir lint",
     "docs": "aegir docs",
     "build": "aegir build",
-    "test": "aegir test -t node -t browser --timeout 10000",
+    "test": "aegir test -t node -t browser --timeout 60000",
     "test:node": "aegir test -t node",
     "test:browser": "aegir test -t browser",
-    "release": "aegir release --timeout 10000",
+    "release": "aegir release --timeout 60000",
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "coverage": "aegir coverage --timeout 50000"
@@ -60,6 +60,7 @@
     "merge-options": "^3.0.1",
     "multiaddr": "^8.0.0",
     "nanoid": "^3.1.3",
+    "p-wait-for": "^3.1.0",
     "temp-write": "^4.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "aegir lint",
     "docs": "aegir docs",
     "build": "aegir build",
-    "test": "aegir test -t node -t browser --timeout 10000",
+    "test": "aegir test",
     "test:node": "aegir test -t node",
     "test:browser": "aegir test -t browser",
     "release": "aegir release --timeout 10000",

--- a/package.json
+++ b/package.json
@@ -11,10 +11,10 @@
     "lint": "aegir lint",
     "docs": "aegir docs",
     "build": "aegir build",
-    "test": "aegir test -t node -t browser --timeout 60000",
+    "test": "aegir test -t node -t browser --timeout 10000",
     "test:node": "aegir test -t node",
     "test:browser": "aegir test -t browser",
-    "release": "aegir release --timeout 60000",
+    "release": "aegir release --timeout 10000",
     "release-minor": "aegir release --type minor",
     "release-major": "aegir release --type major",
     "coverage": "aegir coverage --timeout 50000"

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -276,20 +276,12 @@ class Daemon {
         this.subprocess.cancel()
       }
 
-      try {
-        await this.subprocess
-      } catch (err) {
-        if (!this.subprocess.killed) {
-          throw err
-        }
-      } finally {
-        clearTimeout(killTimeout)
-      }
-
       // wait for the subprocess to exit and declare ourselves stopped
       await waitFor(() => !this.started, {
         timeout
       })
+
+      clearTimeout(killTimeout)
 
       if (this.disposable) {
         // wait for the cleanup routine to run after the subprocess has exited

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -258,8 +258,9 @@ class Daemon {
       return this
     }
 
-    let killTimeout
     if (this.subprocess) {
+      let killTimeout
+
       if (this.disposable) {
         // we're done with this node and will remove it's repo when we are done
         // so don't wait for graceful exit, just terminate the process

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -247,8 +247,8 @@ class Daemon {
   /**
    * Stop the daemon.
    *
-   * @param {object} options
-   * @param {number} options.timeout - How long to wait for the daemon to stop
+   * @param {object} [options]
+   * @param {number} [options.timeout=60000] - How long to wait for the daemon to stop
    * @returns {Promise<Daemon>}
    */
   async stop (options = {}) {

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -289,17 +289,10 @@ class Daemon {
         if (!this.subprocess.killed) {
           throw err
         }
+      } finally {
+        clearTimeout(killTimeout)
       }
 
-      clearTimeout(killTimeout)
-    } else {
-      await this.api.stop()
-    }
-
-    if (!this.subprocess) {
-      // if we have a subprocess, this.started will be set when it exits
-      this.started = false
-    } else {
       // wait for the subprocess to exit and declare ourselves stopped
       await waitFor(() => !this.started, {
         timeout
@@ -311,6 +304,10 @@ class Daemon {
           timeout
         })
       }
+    } else {
+      await this.api.stop()
+
+      this.started = false
     }
 
     return this

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -221,21 +221,14 @@ class Daemon {
           }
         }
         this.subprocess.stdout.on('data', readyHandler)
-        this.subprocess.catch(err => {
-          if (this.started) {
-            this.started = false
-            reject(translateError(err))
-          }
-        })
+        this.subprocess.catch(err => reject(translateError(err)))
         this.subprocess.on('exit', () => {
-          if (this.started) {
-            this.started = false
-            this.subprocess.stderr.removeAllListeners()
-            this.subprocess.stdout.removeAllListeners()
+          this.started = false
+          this.subprocess.stderr.removeAllListeners()
+          this.subprocess.stdout.removeAllListeners()
 
-            if (this.disposable) {
-              this.cleanup().catch(() => {})
-            }
+          if (this.disposable) {
+            this.cleanup().catch(() => {})
           }
         })
       })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -7,6 +7,7 @@ const { createFactory, createController } = require('../src')
 const { repoExists } = require('../src/utils')
 const { isBrowser, isWebWorker, isNode } = require('ipfs-utils/src/env')
 const pathJoin = require('ipfs-utils/src/path-join')
+const retry = require('trytryagain')
 
 /** @typedef {import("../src/index").ControllerOptions} ControllerOptions */
 
@@ -186,6 +187,54 @@ describe('Controller API', function () {
           expect(ctl.started).to.be.true()
           const id = await ctl.api.id()
           expect(factory.controllers[0].api.peerId.id).to.be.eq(id.id)
+        })
+      }
+    })
+
+    describe('should stop a running node that we have joined', () => {
+      for (const opts of types) {
+        it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async function () {
+          if (isBrowser || isWebWorker) {
+            return this.skip() // can't detect remote node shutdown in the browser
+          }
+
+          // have to use createController so we don't try to shut down
+          // the node twice during test cleanup
+          const ctl1 = await createController({
+            type: 'go',
+            ipfsHttpModule: require('ipfs-http-client'),
+            ipfsBin: isNode ? require('go-ipfs').path() : undefined,
+            test: true,
+            disposable: true,
+            ipfsOptions: {
+              init: true,
+              start: true
+            }
+          })
+          expect(ctl1.started).to.be.true()
+
+          const ctl2 = await createController(merge(
+            opts, {
+              ipfsHttpModule: require('ipfs-http-client'),
+              ipfsModule: require('ipfs'),
+              ipfsOptions: {
+                repo: ctl1.path,
+                start: true
+              }
+            }
+          ))
+          expect(ctl2.started).to.be.true()
+
+          await ctl2.stop()
+          expect(ctl2.started).to.be.false()
+
+          // wait for the other subprocess to exit
+          await retry(() => ctl1.started ? Promise.reject(new Error('Still running')) : Promise.resolve(), { // eslint-disable-line max-nested-callbacks
+            timeout: 10000,
+            interval: 100
+          })
+
+          expect(ctl1.started).to.be.false()
         })
       }
     })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -7,7 +7,7 @@ const { createFactory, createController } = require('../src')
 const { repoExists } = require('../src/utils')
 const { isBrowser, isWebWorker, isNode } = require('ipfs-utils/src/env')
 const pathJoin = require('ipfs-utils/src/path-join')
-const retry = require('trytryagain')
+const waitFor = require('p-wait-for')
 
 /** @typedef {import("../src/index").ControllerOptions} ControllerOptions */
 
@@ -229,7 +229,7 @@ describe('Controller API', function () {
           expect(ctl2.started).to.be.false()
 
           // wait for the other subprocess to exit
-          await retry(() => ctl1.started ? Promise.reject(new Error('Still running')) : Promise.resolve(), { // eslint-disable-line max-nested-callbacks
+          await waitFor(() => !ctl1.started, { // eslint-disable-line max-nested-callbacks
             timeout: 10000,
             interval: 100
           })

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -195,28 +195,32 @@ describe('Controller API', function () {
       for (const opts of types) {
         it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async function () {
           if (isBrowser || isWebWorker) {
-            return this.skip() // can't detect remote node shutdown in the browser
+            return this.skip() // browser can't attach to running node
           }
 
           // have to use createController so we don't try to shut down
           // the node twice during test cleanup
-          const ctl1 = await createController({
-            type: 'go',
-            ipfsHttpModule: require('ipfs-http-client'),
-            ipfsBin: isNode ? require('go-ipfs').path() : undefined,
-            test: true,
-            disposable: true,
-            ipfsOptions: {
-              init: true,
-              start: true
-            }
-          })
+          const ctl1 = await createController(merge(
+            {
+              type: 'go',
+              ipfsHttpModule: require('ipfs-http-client'),
+              ipfsBin: require('go-ipfs').path(),
+              test: true,
+              disposable: true,
+              remote: false,
+              ipfsOptions: {
+                init: true,
+                start: true
+              }
+            }))
           expect(ctl1.started).to.be.true()
 
           const ctl2 = await createController(merge(
             opts, {
               ipfsHttpModule: require('ipfs-http-client'),
               ipfsModule: require('ipfs'),
+              test: true,
+              disposable: true,
               ipfsOptions: {
                 repo: ctl1.path,
                 start: true


### PR DESCRIPTION
Fixes two problems:

1. If we use `ipfs-daemon` to connect to a running node, there's no `this.subprocess` only `this.api` so don't reference that property in the `this.stop()` method.
2. There's a delay between stopping the process and the process actually stopping - in CI we don't wait for this and start new tests which start new processes which can overwhelm small weak build machines so wait for the subprocess to stop before returning from `this.stop()`

Changes behaviour:

1. Let the exiting of `this.subprocess` set `this.started = false` instead of when we stop the process
2. If a node is marked `disposable`, we don't really care about it exiting cleanly as we're going to delete it's repo shortly afterwards so just `SIGKILL` it immediately.