### PR TITLE
chore: use `.create` function for http client and ipfs client

### DIFF
--- a/src/ipfsd-client.js
+++ b/src/ipfsd-client.js
@@ -76,12 +76,12 @@ class Client {
    */
   _createApi () {
     if (this.opts.ipfsClientModule && this.grpcAddr && this.apiAddr) {
-      this.api = this.opts.ipfsClientModule({
+      this.api = this.opts.ipfsClientModule.create({
         grpc: this.grpcAddr,
         http: this.apiAddr
       })
     } else if (this.apiAddr) {
-      this.api = this.opts.ipfsHttpModule(this.apiAddr)
+      this.api = this.opts.ipfsHttpModule.create(this.apiAddr)
     }
 
     if (this.api) {

--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -79,12 +79,12 @@ class Daemon {
 
   _createApi () {
     if (this.opts.ipfsClientModule && this.grpcAddr) {
-      this.api = this.opts.ipfsClientModule({
+      this.api = this.opts.ipfsClientModule.create({
         grpc: this.grpcAddr,
         http: this.apiAddr
       })
     } else if (this.apiAddr) {
-      this.api = this.opts.ipfsHttpModule(this.apiAddr)
+      this.api = this.opts.ipfsHttpModule.create(this.apiAddr)
     }
 
     if (!this.api) {

--- a/src/ipfsd-in-proc.js
+++ b/src/ipfsd-in-proc.js
@@ -53,7 +53,7 @@ class InProc {
    */
   _setApi (addr) {
     this.apiAddr = multiaddr(addr)
-    this.api = this.opts.ipfsHttpModule(addr)
+    this.api = this.opts.ipfsHttpModule.create(addr)
     this.api.apiHost = this.apiAddr.nodeAddress().address
     this.api.apiPort = this.apiAddr.nodeAddress().port
   }

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -65,15 +65,19 @@ describe('`createController` should return the correct class', () => {
       type: 'js',
       disposable: false,
       ipfsModule: require('ipfs'),
-      ipfsClientModule: (opts) => {
-        clientCreated = true
+      ipfsClientModule: {
+        create: (opts) => {
+          clientCreated = true
 
-        return require('ipfs-client')(opts)
+          return require('ipfs-client')(opts)
+        }
       },
-      ipfsHttpModule: (opts) => {
-        httpCreated = true
+      ipfsHttpModule: {
+        create: (opts) => {
+          httpCreated = true
 
-        return require('ipfs-http-client')(opts)
+          return require('ipfs-http-client')(opts)
+        }
       },
       ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
     })
@@ -90,15 +94,19 @@ describe('`createController` should return the correct class', () => {
       remote: true,
       disposable: false,
       ipfsModule: require('ipfs'),
-      ipfsClientModule: (opts) => {
-        clientCreated = true
+      ipfsClientModule: {
+        create: (opts) => {
+          clientCreated = true
 
-        return require('ipfs-client')(opts)
+          return require('ipfs-client')(opts)
+        }
       },
-      ipfsHttpModule: (opts) => {
-        httpCreated = true
+      ipfsHttpModule: {
+        create: (opts) => {
+          httpCreated = true
 
-        return require('ipfs-http-client')(opts)
+          return require('ipfs-http-client')(opts)
+        }
       },
       ipfsBin: pathJoin(__dirname, '../node_modules/ipfs/src/cli/bin.js')
     })


### PR DESCRIPTION
ipfs/js-ipfs#3550 switches away from default exports for `ipfs-http-client`
and `ipfs-client` to enable an easier transition to es6 modules.

All `ipfs` modules now export a `.create` factory function which returns
instances of the client module.

BREAKING CHANGE: expects `ipfs-http-client` and `ipfs-client` to export a `.create` function