### PR TITLE
chore: remove peer deps

### DIFF
--- a/.aegir.js
+++ b/.aegir.js
@@ -1,13 +1,24 @@
 'use strict'
 
+const path = require('path')
 const getPort = require('aegir/utils/get-port')
 const createServer = require('./src').createServer
+
+/** @type {import('aegir').Options["build"]["config"]} */
+const esbuild = {
+  inject: [path.join(__dirname, 'scripts/node-globals.js')],
+}
 
 module.exports = {
   bundlesize: {
     maxSize: '35kB'
   },
   test: {
+    browser: {
+      config: {
+        buildConfig: esbuild
+      }
+    },
     before: async () => {
       const server = createServer(undefined, {
           ipfsModule: require('ipfs'),

--- a/.aegir.js
+++ b/.aegir.js
@@ -3,52 +3,35 @@
 const getPort = require('aegir/utils/get-port')
 const createServer = require('./src').createServer
 
-const server = createServer(undefined,
-  {
-    ipfsModule: require('ipfs'),
-    ipfsHttpModule: require('ipfs-http-client')
-  },
-  {
-    go: {
-      ipfsBin: require('go-ipfs').path()
-    },
-    js: {
-      ipfsBin: require.resolve('ipfs/src/cli.js')
-    }
-  }
-)
-
 module.exports = {
-  bundlesize: { maxSize: '35kB' },
-  karma: {
-    files: [{
-      pattern: 'test/fixtures/**/*',
-      watched: false,
-      served: true,
-      included: false
-    }]
+  bundlesize: {
+    maxSize: '35kB'
   },
-  hooks: {
-      pre: async () => {
-        await server.start(await getPort(server.port, server.host))
-        return {
-          env: {
-            IPFSD_CTL_SERVER: `http://${server.host}:${server.port}`
+  test: {
+    before: async () => {
+      const server = createServer(undefined, {
+          ipfsModule: require('ipfs'),
+          ipfsHttpModule: require('ipfs-http-client')
+        }, {
+          go: {
+            ipfsBin: require('go-ipfs').path()
+          },
+          js: {
+            ipfsBin: require.resolve('ipfs/src/cli.js')
           }
         }
-      },
-      post: () => server.stop()
-  },
-  webpack: {
-    node: {
-      // needed by ipfs-repo-migrations
-      path: true,
+      )
 
-      // needed by abstract-leveldown
-      Buffer: true,
-
-      // needed by nofilter
-      stream: true
+      await server.start(await getPort(server.port, server.host))
+      return {
+        env: {
+          IPFSD_CTL_SERVER: `http://${server.host}:${server.port}`
+        },
+        server
+      }
+    },
+    after: async (options, beforeResult) => {
+      await beforeResult.server.stop()
     }
   }
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
+    - run: npm install -g @mapbox/node-pre-gyp
     - run: npm install
     - run: npm run lint
     - run: npm run build
@@ -33,6 +34,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
+      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
       - run: npx nyc --reporter=lcov aegir test -t node --bail --timeout 60000
       - uses: codecov/codecov-action@v1
@@ -41,6 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
       - run: npx aegir test -t browser -t webworker --timeout 10000
   test-firefox:
@@ -48,13 +51,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
-      - run: npx aegir test -t browser -t webworker --timeout 10000 -- --browsers FirefoxHeadless
+      - run: npx aegir test -t browser -t webworker --timeout 10000 -- --browser firefox
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-main --bail --timeout 10000
   test-electron-renderer:
@@ -62,5 +67,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-renderer --bail --timeout 10000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: yarn
-    - run: yarn lint
-    - run: yarn build
-    - run: yarn aegir dep-check
+    - run: npm install
+    - run: npm run lint
+    - run: npm run build
+    - run: npx aegir dep-check
     - uses: ipfs/aegir/actions/bundle-size@master
       name: size
       with:
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: yarn
+      - run: npm install
       - run: npx nyc --reporter=lcov aegir test -t node --bail --timeout 60000
       - uses: codecov/codecov-action@v1
   test-chrome:
@@ -41,26 +41,26 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn
+      - run: npm install
       - run: npx aegir test -t browser -t webworker --timeout 10000
   test-firefox:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn
+      - run: npm install
       - run: npx aegir test -t browser -t webworker --timeout 10000 -- --browsers FirefoxHeadless
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn
+      - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-main --bail --timeout 10000
   test-electron-renderer:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: yarn
+      - run: npm install
       - run: npx xvfb-maybe aegir test -t electron-renderer --bail --timeout 10000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-node@v1
-        with:
-          node-version: 15
+      with:
+        node-version: 15
     - run: npm install -g @mapbox/node-pre-gyp && npm install
     - run: npm run lint
     - run: npm run build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
-        node: [12, 14]
+        node: [14, 15]
       fail-fast: true
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: npm install
+    - uses: actions/setup-node@v1
+        with:
+          node-version: 15
+    - run: npm install -g @mapbox/node-pre-gyp && npm install
     - run: npm run lint
     - run: npm run build
     - run: npx aegir dep-check
@@ -33,7 +36,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
       - run: npx nyc --reporter=lcov aegir test -t node --bail --timeout 60000
       - uses: codecov/codecov-action@v1
   test-chrome:
@@ -41,30 +44,38 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install -g @mapbox/node-pre-gyp
-      - run: npm install
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 15
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
       - run: npx aegir test -t browser -t webworker --timeout 10000
   test-firefox:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install -g @mapbox/node-pre-gyp
-      - run: npm install
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 15
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
       - run: npx aegir test -t browser -t webworker --timeout 10000 -- --browser firefox
   test-electron-main:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install -g @mapbox/node-pre-gyp
-      - run: npm install
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 15
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
       - run: npx xvfb-maybe aegir test -t electron-main --bail --timeout 10000
   test-electron-renderer:
     needs: check
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - run: npm install -g @mapbox/node-pre-gyp
-      - run: npm install
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 15
+      - run: npm install -g @mapbox/node-pre-gyp && npm install
       - run: npx xvfb-maybe aegir test -t electron-renderer --bail --timeout 10000

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
-    - run: npm install -g @mapbox/node-pre-gyp
     - run: npm install
     - run: npm run lint
     - run: npm run build
@@ -34,7 +33,6 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: ${{ matrix.node }}
-      - run: npm install -g @mapbox/node-pre-gyp
       - run: npm install
       - run: npx nyc --reporter=lcov aegir test -t node --bail --timeout 60000
       - uses: codecov/codecov-action@v1

--- a/package.json
+++ b/package.json
@@ -25,14 +25,8 @@
     "./src/ipfsd-daemon.js": "./src/ipfsd-client.js",
     "go-ipfs": false
   },
-  "lint-staged": {
-    "*.js": [
-      "eslint --fix -c node_modules/aegir/src/config/eslintrc.js",
-      "git add"
-    ]
-  },
   "engines": {
-    "node": ">=10.0.0"
+    "node": ">=12.0.0"
   },
   "files": [
     "src",
@@ -58,13 +52,12 @@
     "temp-write": "^4.0.0"
   },
   "devDependencies": {
-    "aegir": "^29.2.2",
+    "aegir": "^33.0.0",
     "benchmark": "^2.1.4",
-    "go-ipfs": "^0.7.0",
-    "ipfs": "^0.52.2",
-    "ipfs-http-client": "^48.1.2",
-    "ipfs-unixfs": "^2.0.3",
-    "lint-staged": "^10.1.6"
+    "go-ipfs": "^0.8.0",
+    "ipfs": "next",
+    "ipfs-http-client": "next",
+    "ipfs-unixfs": "^4.0.1"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "benchmark": "^2.1.4",
     "go-ipfs": "^0.8.0",
     "ipfs": "next",
+    "ipfs-client": "next",
     "ipfs-http-client": "next",
     "ipfs-unixfs": "^4.0.1"
   },

--- a/package.json
+++ b/package.json
@@ -25,12 +25,6 @@
     "./src/ipfsd-daemon.js": "./src/ipfsd-client.js",
     "go-ipfs": false
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged && npx aegir dep-check",
-      "commit-msg": "npx aegir commitlint -- -E HUSKY_GIT_PARAMS"
-    }
-  },
   "lint-staged": {
     "*.js": [
       "eslint --fix -c node_modules/aegir/src/config/eslintrc.js",
@@ -55,7 +49,7 @@
     "debug": "^4.1.1",
     "execa": "^5.0.0",
     "fs-extra": "^9.0.0",
-    "ipfs-utils": "^5.0.1",
+    "ipfs-utils": "^6.0.6",
     "joi": "^17.2.1",
     "merge-options": "^3.0.1",
     "multiaddr": "^8.0.0",
@@ -67,17 +61,10 @@
     "aegir": "^29.2.2",
     "benchmark": "^2.1.4",
     "go-ipfs": "^0.7.0",
-    "husky": "^4.2.5",
     "ipfs": "^0.52.2",
     "ipfs-http-client": "^48.1.2",
     "ipfs-unixfs": "^2.0.3",
     "lint-staged": "^10.1.6"
-  },
-  "peerDependencies": {
-    "go-ipfs": "*",
-    "ipfs": "*",
-    "ipfs-client": "*",
-    "ipfs-http-client": "*"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "aegir": "^33.0.0",
+    "assert": "^2.0.0",
     "benchmark": "^2.1.4",
     "go-ipfs": "^0.8.0",
     "ipfs": "next",

--- a/scripts/node-globals.js
+++ b/scripts/node-globals.js
@@ -1,4 +1,3 @@
-
 // @ts-nocheck
 export const { Buffer } = require('buffer')
 export const __dirname = globalThis.__dirname

--- a/scripts/node-globals.js
+++ b/scripts/node-globals.js
@@ -1,0 +1,4 @@
+
+// @ts-nocheck
+export const { Buffer } = require('buffer')
+export const __dirname = globalThis.__dirname

--- a/src/factory.js
+++ b/src/factory.js
@@ -115,10 +115,12 @@ class Factory {
         start: false,
         init: false
       },
-      opts.test ? {
-        config: testsConfig(opts),
-        preload: { enabled: false }
-      } : {},
+      opts.test
+        ? {
+            config: testsConfig(opts),
+            preload: { enabled: false }
+          }
+        : {},
       opts.ipfsOptions
     )
 

--- a/src/utils.browser.js
+++ b/src/utils.browser.js
@@ -23,8 +23,8 @@ const removeRepo = async (repoPath) => {
 
 const repoExists = (repoPath) => {
   return new Promise((resolve, reject) => {
-    var req = self.indexedDB.open(repoPath)
-    var existed = true
+    const req = self.indexedDB.open(repoPath)
+    let existed = true
     req.onerror = () => reject(req.error)
     req.onsuccess = function () {
       req.result.close()

--- a/test/factory.spec.js
+++ b/test/factory.spec.js
@@ -5,7 +5,7 @@ const { expect } = require('aegir/utils/chai')
 const { isNode } = require('ipfs-utils/src/env')
 const pathJoin = require('ipfs-utils/src/path-join')
 const { createFactory } = require('../src')
-const UnixFS = require('ipfs-unixfs')
+const { UnixFS } = require('ipfs-unixfs')
 
 const defaultOps = {
   ipfsHttpModule: require('ipfs-http-client')

--- a/test/node.routes.js
+++ b/test/node.routes.js
@@ -6,7 +6,9 @@ const Hapi = require('@hapi/hapi')
 const routes = require('../src/endpoint/routes')
 const { createFactory } = require('../src')
 
-describe('routes', () => {
+describe('routes', function () {
+  this.timeout(60000)
+
   let id
   let server
 

--- a/test/node.utils.js
+++ b/test/node.utils.js
@@ -9,6 +9,8 @@ const { tmpDir, checkForRunningApi, defaultRepo, repoExists, removeRepo, buildIn
 const { createFactory, createController } = require('../src')
 
 describe('utils node version', function () {
+  this.timeout(60000)
+
   it('tmpDir should return correct path', () => {
     expect(tmpDir('js')).to.be.contain(path.join(os.tmpdir(), 'js_ipfs_'))
     expect(tmpDir('go')).to.be.contain(path.join(os.tmpdir(), 'go_ipfs_'))


### PR DESCRIPTION
We added ipfs, the http client etc as peer deps to signal to the user
that they should add the modules they depend on as deps of their project.

Starting with npm7 all peer deps get installed automatically which
defeats the purpose of our use of peer deps, so let's remove them.