### PR TITLE
fix: add factory opts and use ipfs api

### DIFF
--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,7 +1,6 @@
 
 import { EventEmitter } from 'events'
 import { IPFS } from 'ipfs-core-types'
-import { IDResult } from 'ipfs-core-types/src/root'
 
 export interface Subprocess {
   stderr: EventEmitter | null

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -8,16 +8,6 @@ export interface Subprocess {
   stdout: EventEmitter | null
 }
 
-export interface API extends IPFS {
-  peerId: IDResult
-  apiHost: string
-  apiPort: string
-  gatewayHost: string
-  gatewayPort: string
-  grpcHost: string
-  grpcPort: string
-}
-
 export interface Controller {
   init: (options?: InitOptions) => Promise<Controller>
   start: () => Promise<Controller>
@@ -29,7 +19,7 @@ export interface Controller {
   started: boolean
   initialized: boolean
   clean: boolean
-  api: API
+  api: IPFS
   subprocess?: Subprocess | null
   opts: ControllerOptions
 }
@@ -207,4 +197,5 @@ export interface Factory {
   spawn: (options?: ControllerOptions) => Promise<Controller>
   clean: () => Promise<void>
   controllers: Controller[]
+  opts: ControllerOptions
 }

--- a/test/controller.spec.js
+++ b/test/controller.spec.js
@@ -203,8 +203,6 @@ describe('Controller API', function () {
           await ctl.init()
           await ctl.start()
           expect(ctl.started).to.be.true()
-          const id = await ctl.api.id()
-          expect(factory.controllers[0].api.peerId.id).to.be.eq(id.id)
         })
       }
     })

--- a/test/create.spec.js
+++ b/test/create.spec.js
@@ -172,16 +172,6 @@ const types = [{
   remote: true
 }]
 
-describe('`createController` should return daemon with peerId when started', () => {
-  for (const opts of types) {
-    it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
-      const node = await createController(opts)
-      expect(node.api.peerId).to.exist()
-      await node.stop()
-    })
-  }
-})
-
 describe('`createController({test: true})` should return daemon with test profile', () => {
   for (const opts of types) {
     it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {


### PR DESCRIPTION
Add `.opts` arg to `Factory` interface as it's used by the `interface-ipfs-core` tests.

Also stop extending IPFS, just use the core api and if you need id/config details call the relevant API methods instead.