### PR TITLE
fix: silence deprecation warning for fs.rmdir

### DIFF
--- a/src/ipfsd-daemon.js
+++ b/src/ipfsd-daemon.js
@@ -172,7 +172,7 @@ class Daemon {
    */
   async cleanup () {
     if (!this.clean) {
-      await fs.rmdir(this.path, {
+      await fs.rm(this.path, {
         recursive: true
       })
       this.clean = true

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,7 +14,7 @@ const log = debug('ipfsd-ctl:utils')
  */
 const removeRepo = async (repoPath) => {
   try {
-    await fs.promises.rmdir(repoPath, {
+    await fs.promises.rm(repoPath, {
       recursive: true
     })
   } catch (err) {


### PR DESCRIPTION
`fs.rmdir` with the `recursive` option is deprecated in favour of `fs.rm`
with the `recursive` operation, so use that instead.