### PR TITLE
chore: re-enable tests that use isOnline

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,7 +145,7 @@
     "@libp2p/logger": "^4.0.10",
     "execa": "^8.0.1",
     "joi": "^17.2.1",
-    "kubo-rpc-client": "^4.0.0",
+    "kubo-rpc-client": "^4.0.1",
     "merge-options": "^3.0.1",
     "nanoid": "^5.0.7",
     "p-defer": "^4.0.1",

--- a/test/controller.spec.ts
+++ b/test/controller.spec.ts
@@ -163,8 +163,7 @@ describe('Node API', function () {
   })
 
   describe('stop', () => {
-    // https://github.com/ipfs/js-kubo-rpc-client/pull/222
-    describe.skip('should stop the node', () => {
+    describe('should stop the node', () => {
       for (const opts of types) {
         it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
           const node = await factory.spawn(opts)

--- a/test/factory.spec.ts
+++ b/test/factory.spec.ts
@@ -107,8 +107,7 @@ describe('`Factory spawn()` ', function () {
     }
   })
 
-  // https://github.com/ipfs/js-kubo-rpc-client/pull/222
-  describe.skip('`Factory.clean()` should stop all nodes', () => {
+  describe('`Factory.clean()` should stop all nodes', () => {
     let factory: Factory
 
     afterEach(async () => {
@@ -127,8 +126,7 @@ describe('`Factory spawn()` ', function () {
     }
   })
 
-  // https://github.com/ipfs/js-kubo-rpc-client/pull/222
-  describe.skip('`Factory.clean()` should not error when controller already stopped', () => {
+  describe('`Factory.clean()` should not error when controller already stopped', () => {
     let factory: Factory
 
     afterEach(async () => {


### PR DESCRIPTION
Now that isOnline will not throw when the node is offline, re-enable tests that use this API call.