### PR TITLE
fix: return gateway maddr in .info response

### DIFF
--- a/src/kubo/index.ts
+++ b/src/kubo/index.ts
@@ -75,6 +75,7 @@ export interface KuboInfo {
   multiaddrs: string[]
   api?: string
   repo: string
+  gateway: string
 }
 
 export interface KuboNode extends Node<KuboRPCClient, KuboOptions, KuboInfo, KuboInitOptions, KuboStartOptions, KuboStopOptions> {

--- a/test/controller.spec.ts
+++ b/test/controller.spec.ts
@@ -208,4 +208,25 @@ describe('Node API', function () {
       }
     })
   })
+
+  describe('info', () => {
+    describe('should return the node info', () => {
+      for (const opts of types) {
+        it(`type: ${opts.type} remote: ${Boolean(opts.remote)}`, async () => {
+          const node = await factory.spawn(opts)
+          const info = await node.info()
+
+          expect(info).to.have.property('version').that.is.a('string')
+          expect(info).to.have.property('api').that.is.a('string')
+          expect(info).to.have.property('peerId').that.is.a('string')
+          expect(info).to.have.property('repo').that.is.a('string')
+          expect(info).to.have.property('pid').that.is.a('number')
+          expect(info).to.have.property('multiaddrs').that.is.an('array')
+          expect(info).to.have.property('gateway').that.is.a('string').that.matches(/\/ip4\/127\.0\.0\.1\/tcp\/\d+/)
+
+          await node.stop()
+        })
+      }
+    })
+  })
 })

--- a/test/endpoint/routes.node.ts
+++ b/test/endpoint/routes.node.ts
@@ -109,6 +109,8 @@ describe('routes', function () {
       expect(res.result).to.have.property('api').that.is.a('string')
       expect(res.result).to.have.property('repo').that.is.a('string')
       expect(res.result).to.have.property('multiaddrs').that.is.an('array')
+      expect(res.result).to.have.property('peerId').that.is.a('string')
+      expect(res.result).to.have.property('gateway').that.is.a('string')
     })
 
     it('should return 400', async () => {


### PR DESCRIPTION
In order to not re-add the multiaddr dependency, we're just returning the gateway response as a string. Users will need to parse the string with `@multiformats/multiaddr` or other means.

Fixes #831
