### PR TITLE
deps!: update libp2p and kubo

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,20 +142,20 @@
   "dependencies": {
     "@hapi/boom": "^10.0.0",
     "@hapi/hapi": "^21.1.0",
-    "@libp2p/interface": "^2.0.1",
-    "@libp2p/logger": "^5.0.1",
+    "@libp2p/interface": "^3.0.2",
+    "@libp2p/logger": "^6.0.5",
     "execa": "^9.3.1",
-    "joi": "^17.2.1",
-    "kubo-rpc-client": "^5.0.0",
+    "joi": "^18.0.1",
+    "kubo-rpc-client": "^6.0.0",
     "merge-options": "^3.0.1",
     "nanoid": "^5.0.7",
     "p-defer": "^4.0.1",
-    "p-wait-for": "^5.0.0",
+    "p-wait-for": "^6.0.0",
     "wherearewe": "^2.0.1"
   },
   "devDependencies": {
     "aegir": "^47.0.22",
-    "kubo": "^0.32.0"
+    "kubo": "^0.38.1"
   },
   "browser": {
     "./dist/src/endpoint/server.js": "./dist/src/endpoint/server.browser.js",


### PR DESCRIPTION
BREAKING CHANGE: uses libp2p@3.x.x deps and updates to latest kubo